### PR TITLE
ベンチマーク起動のgRPCサーバー実装

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
     wrapcheck:
       extra-ignore-sigs:
         - (github.com/labstack/echo/v4.Context).
+        - func google.golang.org/grpc/status.Error
   exclusions:
     generated: lax
     presets:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"log"
 	"os"
 
 	"github.com/go-sql-driver/mysql"
@@ -9,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/traPtitech/piscon-portal-v2/server/handler"
 	dbrepo "github.com/traPtitech/piscon-portal-v2/server/repository/db"
+	"github.com/traPtitech/piscon-portal-v2/server/server"
 	"github.com/traPtitech/piscon-portal-v2/server/services/oauth2"
 	"github.com/traPtitech/piscon-portal-v2/server/usecase"
 )
@@ -49,6 +51,11 @@ func main() {
 		panic(err)
 	}
 	handler.SetupRoutes(e)
+
+	benchService := server.NewBenchmarkService(useCase)
+	go func() {
+		log.Fatal("error in bench service.", server.Start(50051, benchService))
+	}()
 
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/server/repository/mock/repository.go
+++ b/server/repository/mock/repository.go
@@ -506,6 +506,45 @@ func (c *MockRepositoryGetBenchmarksCall) DoAndReturn(f func(context.Context, re
 	return c
 }
 
+// GetOldestQueuedBenchmark mocks base method.
+func (m *MockRepository) GetOldestQueuedBenchmark(ctx context.Context) (domain.Benchmark, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOldestQueuedBenchmark", ctx)
+	ret0, _ := ret[0].(domain.Benchmark)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOldestQueuedBenchmark indicates an expected call of GetOldestQueuedBenchmark.
+func (mr *MockRepositoryMockRecorder) GetOldestQueuedBenchmark(ctx any) *MockRepositoryGetOldestQueuedBenchmarkCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOldestQueuedBenchmark", reflect.TypeOf((*MockRepository)(nil).GetOldestQueuedBenchmark), ctx)
+	return &MockRepositoryGetOldestQueuedBenchmarkCall{Call: call}
+}
+
+// MockRepositoryGetOldestQueuedBenchmarkCall wrap *gomock.Call
+type MockRepositoryGetOldestQueuedBenchmarkCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryGetOldestQueuedBenchmarkCall) Return(arg0 domain.Benchmark, arg1 error) *MockRepositoryGetOldestQueuedBenchmarkCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryGetOldestQueuedBenchmarkCall) Do(f func(context.Context) (domain.Benchmark, error)) *MockRepositoryGetOldestQueuedBenchmarkCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryGetOldestQueuedBenchmarkCall) DoAndReturn(f func(context.Context) (domain.Benchmark, error)) *MockRepositoryGetOldestQueuedBenchmarkCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetTeams mocks base method.
 func (m *MockRepository) GetTeams(ctx context.Context) ([]domain.Team, error) {
 	m.ctrl.T.Helper()
@@ -618,6 +657,44 @@ func (c *MockRepositoryTransactionCall) Do(f func(context.Context, func(context.
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockRepositoryTransactionCall) DoAndReturn(f func(context.Context, func(context.Context, repository.Repository) error) error) *MockRepositoryTransactionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// UpdateBenchmark mocks base method.
+func (m *MockRepository) UpdateBenchmark(ctx context.Context, id uuid.UUID, benchmark domain.Benchmark) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateBenchmark", ctx, id, benchmark)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateBenchmark indicates an expected call of UpdateBenchmark.
+func (mr *MockRepositoryMockRecorder) UpdateBenchmark(ctx, id, benchmark any) *MockRepositoryUpdateBenchmarkCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBenchmark", reflect.TypeOf((*MockRepository)(nil).UpdateBenchmark), ctx, id, benchmark)
+	return &MockRepositoryUpdateBenchmarkCall{Call: call}
+}
+
+// MockRepositoryUpdateBenchmarkCall wrap *gomock.Call
+type MockRepositoryUpdateBenchmarkCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryUpdateBenchmarkCall) Return(arg0 error) *MockRepositoryUpdateBenchmarkCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryUpdateBenchmarkCall) Do(f func(context.Context, uuid.UUID, domain.Benchmark) error) *MockRepositoryUpdateBenchmarkCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryUpdateBenchmarkCall) DoAndReturn(f func(context.Context, uuid.UUID, domain.Benchmark) error) *MockRepositoryUpdateBenchmarkCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -51,7 +51,6 @@ type Repository interface {
 	// If there are no queued benchmarks, it returns [ErrNotFound].
 	GetOldestQueuedBenchmark(ctx context.Context) (domain.Benchmark, error)
 	// UpdateBenchmark updates a benchmark record.
-	// If the benchmark is not found, it returns [ErrNotFound].
 	UpdateBenchmark(ctx context.Context, id uuid.UUID, benchmark domain.Benchmark) error
 
 	// FindInstance finds an instance by id. If the instance is not found, it returns [ErrNotFound].

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -47,6 +47,12 @@ type Repository interface {
 	FindBenchmark(ctx context.Context, id uuid.UUID) (domain.Benchmark, error)
 	// GetBenchmarkLog returns a benchmark log.
 	GetBenchmarkLog(ctx context.Context, benchmarkID uuid.UUID) (domain.BenchmarkLog, error)
+	// GetOldestQueuedBenchmark returns the oldest queued benchmark.
+	// If there are no queued benchmarks, it returns [ErrNotFound].
+	GetOldestQueuedBenchmark(ctx context.Context) (domain.Benchmark, error)
+	// UpdateBenchmark updates a benchmark record.
+	// If the benchmark is not found, it returns [ErrNotFound].
+	UpdateBenchmark(ctx context.Context, id uuid.UUID, benchmark domain.Benchmark) error
 
 	// FindInstance finds an instance by id. If the instance is not found, it returns [ErrNotFound].
 	FindInstance(ctx context.Context, id uuid.UUID) (domain.Instance, error)

--- a/server/server/benchmark.go
+++ b/server/server/benchmark.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	portalv1 "github.com/traPtitech/piscon-portal-v2/gen/portal/v1"
 	"github.com/traPtitech/piscon-portal-v2/server/usecase"
@@ -31,7 +30,7 @@ func (bs *BenchmarkService) GetBenchmarkJob(ctx context.Context, _ *portalv1.Get
 		}, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("start benchmark: %w", err)
+		return nil, handleError("failed to start benchmark", err)
 	}
 
 	return &portalv1.GetBenchmarkJobResponse{

--- a/server/server/benchmark.go
+++ b/server/server/benchmark.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	portalv1 "github.com/traPtitech/piscon-portal-v2/gen/portal/v1"
+	"github.com/traPtitech/piscon-portal-v2/server/usecase"
+	"google.golang.org/grpc"
+)
+
+type BenchmarkService struct {
+	b usecase.BenchmarkUseCase
+	portalv1.UnimplementedBenchmarkServiceServer
+}
+
+func NewBenchmarkService(u usecase.BenchmarkUseCase) *BenchmarkService {
+	return &BenchmarkService{
+		b: u,
+	}
+}
+
+var _ portalv1.BenchmarkServiceServer = (*BenchmarkService)(nil)
+
+func (bs *BenchmarkService) GetBenchmarkJob(ctx context.Context, _ *portalv1.GetBenchmarkJobRequest) (*portalv1.GetBenchmarkJobResponse, error) {
+	bench, err := bs.b.StartBenchmark(ctx)
+	if errors.Is(err, usecase.ErrNotFound) {
+		return &portalv1.GetBenchmarkJobResponse{
+			BenchmarkJob: nil,
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("start benchmark: %w", err)
+	}
+
+	return &portalv1.GetBenchmarkJobResponse{
+		BenchmarkJob: &portalv1.BenchmarkJob{
+			BenchmarkId: bench.ID.String(),
+			TargetUrl:   bench.Instance.PrivateIP,
+		},
+	}, nil
+}
+
+func (bs *BenchmarkService) SendBenchmarkProgress(grpc.ClientStreamingServer[portalv1.SendBenchmarkProgressRequest, portalv1.SendBenchmarkProgressResponse]) error {
+	// TODO
+	return nil
+}
+func (bs *BenchmarkService) PostJobFinished(context.Context, *portalv1.PostJobFinishedRequest) (*portalv1.PostJobFinishedResponse, error) {
+	// TODO
+	return nil, nil
+}

--- a/server/server/benchmark_test.go
+++ b/server/server/benchmark_test.go
@@ -43,7 +43,7 @@ func TestGetBenchmarkJob(t *testing.T) {
 		},
 		"StartBenchmarkがエラー": {
 			StartBenchmarkErr: assert.AnError,
-			err:               assert.AnError,
+			err:               server.ExportedInternalError,
 		},
 	}
 

--- a/server/server/benchmark_test.go
+++ b/server/server/benchmark_test.go
@@ -1,0 +1,80 @@
+package server_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	portalv1 "github.com/traPtitech/piscon-portal-v2/gen/portal/v1"
+	"github.com/traPtitech/piscon-portal-v2/server/domain"
+	"github.com/traPtitech/piscon-portal-v2/server/server"
+	"github.com/traPtitech/piscon-portal-v2/server/usecase"
+	"github.com/traPtitech/piscon-portal-v2/server/usecase/mock"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetBenchmarkJob(t *testing.T) {
+	t.Parallel()
+
+	benchID := uuid.New()
+	targetIP := "0.0.0.0"
+
+	testCases := map[string]struct {
+		bench             domain.Benchmark
+		StartBenchmarkErr error
+		job               *portalv1.BenchmarkJob
+		err               error
+	}{
+		"正常に取得できる": {
+			bench: domain.Benchmark{
+				ID: benchID,
+				Instance: domain.Instance{
+					PrivateIP: targetIP,
+				},
+			},
+			job: &portalv1.BenchmarkJob{
+				BenchmarkId: benchID.String(),
+				TargetUrl:   targetIP,
+			},
+		},
+		"StartBenchmarkがErrNotFound": {
+			StartBenchmarkErr: usecase.ErrNotFound,
+			job:               nil,
+		},
+		"StartBenchmarkがエラー": {
+			StartBenchmarkErr: assert.AnError,
+			err:               assert.AnError,
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			u := mock.NewMockUseCase(ctrl)
+			s := server.NewBenchmarkService(u)
+
+			u.EXPECT().StartBenchmark(gomock.Any()).Return(testCase.bench, testCase.StartBenchmarkErr)
+
+			res, err := s.GetBenchmarkJob(t.Context(), &portalv1.GetBenchmarkJobRequest{})
+
+			if testCase.err != nil {
+				assert.ErrorIs(t, err, testCase.err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			if testCase.job != nil {
+				assert.Equal(t, testCase.job, res.BenchmarkJob)
+			} else {
+				assert.Nil(t, res.BenchmarkJob)
+			}
+		})
+	}
+}

--- a/server/server/export_test.go
+++ b/server/server/export_test.go
@@ -1,0 +1,3 @@
+package server
+
+var ExportedInternalError = internalError

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	portalv1 "github.com/traPtitech/piscon-portal-v2/gen/portal/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Start(port int, benchmarkSvc portalv1.BenchmarkServiceServer) error {
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return fmt.Errorf("net listen: %w", err)
+	}
+
+	s := grpc.NewServer()
+
+	portalv1.RegisterBenchmarkServiceServer(s, benchmarkSvc)
+
+	log.Println("gRPC server started on port", port)
+	err = s.Serve(listener)
+	if err != nil {
+		return fmt.Errorf("grpc serve: %w", err)
+	}
+	defer s.Stop()
+	return nil
+}
+
+func handleError(msg string, err error) error {
+	log.Println(msg, err)
+	return status.Error(codes.Internal, "internal error")
+}

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -30,7 +30,9 @@ func Start(port int, benchmarkSvc portalv1.BenchmarkServiceServer) error {
 	return nil
 }
 
+var internalError = status.Error(codes.Internal, "internal error")
+
 func handleError(msg string, err error) error {
 	log.Println(msg, err)
-	return status.Error(codes.Internal, "internal error")
+	return internalError
 }

--- a/server/usecase/mock/usecase.go
+++ b/server/usecase/mock/usecase.go
@@ -12,6 +12,7 @@ package mock
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	uuid "github.com/google/uuid"
 	domain "github.com/traPtitech/piscon-portal-v2/server/domain"
@@ -117,6 +118,44 @@ func (c *MockUseCaseCreateTeamCall) Do(f func(context.Context, usecase.CreateTea
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockUseCaseCreateTeamCall) DoAndReturn(f func(context.Context, usecase.CreateTeamInput) (domain.Team, error)) *MockUseCaseCreateTeamCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// FinalizeBenchmark mocks base method.
+func (m *MockUseCase) FinalizeBenchmark(ctx context.Context, benchmarkID uuid.UUID, result domain.BenchmarkResult, finishedAt time.Time, errorMessage string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FinalizeBenchmark", ctx, benchmarkID, result, finishedAt, errorMessage)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FinalizeBenchmark indicates an expected call of FinalizeBenchmark.
+func (mr *MockUseCaseMockRecorder) FinalizeBenchmark(ctx, benchmarkID, result, finishedAt, errorMessage any) *MockUseCaseFinalizeBenchmarkCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeBenchmark", reflect.TypeOf((*MockUseCase)(nil).FinalizeBenchmark), ctx, benchmarkID, result, finishedAt, errorMessage)
+	return &MockUseCaseFinalizeBenchmarkCall{Call: call}
+}
+
+// MockUseCaseFinalizeBenchmarkCall wrap *gomock.Call
+type MockUseCaseFinalizeBenchmarkCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockUseCaseFinalizeBenchmarkCall) Return(arg0 error) *MockUseCaseFinalizeBenchmarkCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockUseCaseFinalizeBenchmarkCall) Do(f func(context.Context, uuid.UUID, domain.BenchmarkResult, time.Time, string) error) *MockUseCaseFinalizeBenchmarkCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockUseCaseFinalizeBenchmarkCall) DoAndReturn(f func(context.Context, uuid.UUID, domain.BenchmarkResult, time.Time, string) error) *MockUseCaseFinalizeBenchmarkCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -468,6 +507,83 @@ func (c *MockUseCaseGetUsersCall) Do(f func(context.Context) ([]domain.User, err
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockUseCaseGetUsersCall) DoAndReturn(f func(context.Context) ([]domain.User, error)) *MockUseCaseGetUsersCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SaveBenchmarkProgress mocks base method.
+func (m *MockUseCase) SaveBenchmarkProgress(ctx context.Context, benchmarkID uuid.UUID, benchLog domain.BenchmarkLog, score int64, startedAt time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveBenchmarkProgress", ctx, benchmarkID, benchLog, score, startedAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SaveBenchmarkProgress indicates an expected call of SaveBenchmarkProgress.
+func (mr *MockUseCaseMockRecorder) SaveBenchmarkProgress(ctx, benchmarkID, benchLog, score, startedAt any) *MockUseCaseSaveBenchmarkProgressCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveBenchmarkProgress", reflect.TypeOf((*MockUseCase)(nil).SaveBenchmarkProgress), ctx, benchmarkID, benchLog, score, startedAt)
+	return &MockUseCaseSaveBenchmarkProgressCall{Call: call}
+}
+
+// MockUseCaseSaveBenchmarkProgressCall wrap *gomock.Call
+type MockUseCaseSaveBenchmarkProgressCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockUseCaseSaveBenchmarkProgressCall) Return(arg0 error) *MockUseCaseSaveBenchmarkProgressCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockUseCaseSaveBenchmarkProgressCall) Do(f func(context.Context, uuid.UUID, domain.BenchmarkLog, int64, time.Time) error) *MockUseCaseSaveBenchmarkProgressCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockUseCaseSaveBenchmarkProgressCall) DoAndReturn(f func(context.Context, uuid.UUID, domain.BenchmarkLog, int64, time.Time) error) *MockUseCaseSaveBenchmarkProgressCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// StartBenchmark mocks base method.
+func (m *MockUseCase) StartBenchmark(ctx context.Context) (domain.Benchmark, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartBenchmark", ctx)
+	ret0, _ := ret[0].(domain.Benchmark)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartBenchmark indicates an expected call of StartBenchmark.
+func (mr *MockUseCaseMockRecorder) StartBenchmark(ctx any) *MockUseCaseStartBenchmarkCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartBenchmark", reflect.TypeOf((*MockUseCase)(nil).StartBenchmark), ctx)
+	return &MockUseCaseStartBenchmarkCall{Call: call}
+}
+
+// MockUseCaseStartBenchmarkCall wrap *gomock.Call
+type MockUseCaseStartBenchmarkCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockUseCaseStartBenchmarkCall) Return(arg0 domain.Benchmark, arg1 error) *MockUseCaseStartBenchmarkCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockUseCaseStartBenchmarkCall) Do(f func(context.Context) (domain.Benchmark, error)) *MockUseCaseStartBenchmarkCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockUseCaseStartBenchmarkCall) DoAndReturn(f func(context.Context) (domain.Benchmark, error)) *MockUseCaseStartBenchmarkCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
大きくなりそうなので、とりあえず1つだけ実装しました。

- **:adhesive_bandage: repositoryでベンチマーク関連のinterface定義**
- **:sparkles: usecaseのStartBenchmarkメソッドを実装**
- **:factory: モックの生成**
- **:sparkles: GetOldestQueuedBenchmarkの実装**
- **:sparkles: UpdateBenchmarkの実装**
- **:sparkles: GetBenchmarkJobの実装**
- **:sparkles: gRPCサーバーの初期化**
- **:adhesive_bandage: エラーをログに残す**
- **:sparkles: gRPCサーバー起動**
