### PR TITLE
トランザクションの引数を変更

### DIFF
--- a/server/handler/oauth2_test.go
+++ b/server/handler/oauth2_test.go
@@ -41,8 +41,8 @@ func TestLoginAsExistingUser(t *testing.T) {
 
 	// user already exists, so only create session
 	mockRepo.EXPECT().Transaction(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, f func(context.Context, repository.Repository) error) error {
-			return f(ctx, mockRepo)
+		DoAndReturn(func(ctx context.Context, f func(context.Context) error) error {
+			return f(ctx)
 		})
 	mockRepo.EXPECT().FindUser(gomock.Any(), gomock.Any()).Return(domain.User{ID: userID}, nil)
 	mockRepo.EXPECT().
@@ -91,8 +91,8 @@ func TestLogout(t *testing.T) {
 func testFirstLogin(t *testing.T, mockRepo *repomock.MockRepository, server *httptest.Server, client *http.Client, userID uuid.UUID) {
 	// create user and session
 	mockRepo.EXPECT().Transaction(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, f func(context.Context, repository.Repository) error) error {
-			return f(ctx, mockRepo)
+		DoAndReturn(func(ctx context.Context, f func(context.Context) error) error {
+			return f(ctx)
 		})
 	mockRepo.EXPECT().FindUser(gomock.Any(), gomock.Eq(userID)).Return(domain.User{}, repository.ErrNotFound)
 	mockRepo.EXPECT().

--- a/server/repository/db/repository.go
+++ b/server/repository/db/repository.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/stephenafamo/bob"
-	"github.com/traPtitech/piscon-portal-v2/server/repository"
 )
 
 type repoDB struct {
@@ -41,7 +40,7 @@ func NewRepository(db *sql.DB) *Repository {
 	}
 }
 
-func (r *Repository) Transaction(ctx context.Context, f func(ctx context.Context, r repository.Repository) error) error {
+func (r *Repository) Transaction(ctx context.Context, f func(ctx context.Context) error) error {
 	tx, err := r._db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
@@ -50,7 +49,7 @@ func (r *Repository) Transaction(ctx context.Context, f func(ctx context.Context
 
 	ctx = context.WithValue(ctx, executorCtxKey, tx)
 
-	err = f(ctx, r)
+	err = f(ctx)
 	if err != nil {
 		return err
 	}

--- a/server/repository/db/team.go
+++ b/server/repository/db/team.go
@@ -44,7 +44,7 @@ func (r *Repository) GetTeams(ctx context.Context) ([]domain.Team, error) {
 
 func (r *Repository) CreateTeam(ctx context.Context, team domain.Team) error {
 	if ctx.Value(executorCtxKey) == nil {
-		return r.Transaction(ctx, func(ctx context.Context, r repository.Repository) error {
+		return r.Transaction(ctx, func(ctx context.Context) error {
 			return r.CreateTeam(ctx, team)
 		})
 	}
@@ -75,7 +75,7 @@ func (r *Repository) CreateTeam(ctx context.Context, team domain.Team) error {
 
 func (r *Repository) UpdateTeam(ctx context.Context, team domain.Team) error {
 	if ctx.Value(executorCtxKey) == nil {
-		return r.Transaction(ctx, func(ctx context.Context, r repository.Repository) error {
+		return r.Transaction(ctx, func(ctx context.Context) error {
 			return r.UpdateTeam(ctx, team)
 		})
 	}

--- a/server/repository/mock/repository.go
+++ b/server/repository/mock/repository.go
@@ -624,7 +624,7 @@ func (c *MockRepositoryGetUsersCall) DoAndReturn(f func(context.Context) ([]doma
 }
 
 // Transaction mocks base method.
-func (m *MockRepository) Transaction(ctx context.Context, f func(context.Context, repository.Repository) error) error {
+func (m *MockRepository) Transaction(ctx context.Context, f func(context.Context) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Transaction", ctx, f)
 	ret0, _ := ret[0].(error)
@@ -650,13 +650,13 @@ func (c *MockRepositoryTransactionCall) Return(arg0 error) *MockRepositoryTransa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRepositoryTransactionCall) Do(f func(context.Context, func(context.Context, repository.Repository) error) error) *MockRepositoryTransactionCall {
+func (c *MockRepositoryTransactionCall) Do(f func(context.Context, func(context.Context) error) error) *MockRepositoryTransactionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRepositoryTransactionCall) DoAndReturn(f func(context.Context, func(context.Context, repository.Repository) error) error) *MockRepositoryTransactionCall {
+func (c *MockRepositoryTransactionCall) DoAndReturn(f func(context.Context, func(context.Context) error) error) *MockRepositoryTransactionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/server/repository/repository.go
+++ b/server/repository/repository.go
@@ -13,7 +13,7 @@ import (
 type Repository interface {
 	// Transaction starts a transaction and calls f with the transaction.
 	// If f returns an error, the transaction is rolled back and the error is returned.
-	Transaction(ctx context.Context, f func(ctx context.Context, r Repository) error) error
+	Transaction(ctx context.Context, f func(ctx context.Context) error) error
 
 	// FindUser finds a user by id. If the user is not found, it returns [ErrNotFound].
 	FindUser(ctx context.Context, id uuid.UUID) (domain.User, error)

--- a/server/usecase/benchmark_test.go
+++ b/server/usecase/benchmark_test.go
@@ -43,8 +43,8 @@ func TestCreateBenchmark(t *testing.T) {
 					}, nil)
 				mockRepo.EXPECT().
 					Transaction(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, f func(context.Context, repository.Repository) error) error {
-						return f(ctx, mockRepo)
+					DoAndReturn(func(ctx context.Context, f func(context.Context) error) error {
+						return f(ctx)
 					})
 				mockRepo.EXPECT().
 					GetBenchmarks(gomock.Any(), gomock.Any()).
@@ -58,8 +58,8 @@ func TestCreateBenchmark(t *testing.T) {
 			setup: func(mockRepo *mock.MockRepository) {
 				mockRepo.EXPECT().
 					Transaction(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, f func(context.Context, repository.Repository) error) error {
-						return f(ctx, mockRepo)
+					DoAndReturn(func(ctx context.Context, f func(context.Context) error) error {
+						return f(ctx)
 					})
 				mockRepo.EXPECT().
 					FindUser(gomock.Any(), gomock.Eq(userID)).
@@ -82,8 +82,8 @@ func TestCreateBenchmark(t *testing.T) {
 			setup: func(mockRepo *mock.MockRepository) {
 				mockRepo.EXPECT().
 					Transaction(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, f func(context.Context, repository.Repository) error) error {
-						return f(ctx, mockRepo)
+					DoAndReturn(func(ctx context.Context, f func(context.Context) error) error {
+						return f(ctx)
 					})
 				mockRepo.EXPECT().
 					FindUser(gomock.Any(), gomock.Eq(userID)).
@@ -102,8 +102,8 @@ func TestCreateBenchmark(t *testing.T) {
 			setup: func(mockRepo *mock.MockRepository) {
 				mockRepo.EXPECT().
 					Transaction(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, f func(context.Context, repository.Repository) error) error {
-						return f(ctx, mockRepo)
+					DoAndReturn(func(ctx context.Context, f func(context.Context) error) error {
+						return f(ctx)
 					})
 				mockRepo.EXPECT().
 					FindUser(gomock.Any(), gomock.Eq(userID)).
@@ -139,8 +139,8 @@ func TestCreateBenchmark(t *testing.T) {
 					}, nil)
 				mockRepo.EXPECT().
 					Transaction(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(ctx context.Context, f func(context.Context, repository.Repository) error) error {
-						return f(ctx, mockRepo)
+					DoAndReturn(func(ctx context.Context, f func(context.Context) error) error {
+						return f(ctx)
 					})
 				mockRepo.EXPECT().
 					GetBenchmarks(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
ctxにトランザクションの情報が入るので、repositoryを受け取る必要がない