### PR TITLE
サーバーのgetScoresの実装

### DIFF
--- a/client/src/api/openapi.ts
+++ b/client/src/api/openapi.ts
@@ -339,7 +339,7 @@ export interface paths {
     }
     /**
      * 全てのスコア取得
-     * @description 全てのベンチマークのスコアをチームごとに取得します (0件の場合も200で空配列が返ります)
+     * @description 全てのベンチマークのスコアをチームごとに取得します (0件の場合も200で空配列が返ります)。スコアは古い順に並んでいます。チームの順番は任意です。
      */
     get: operations['getScores']
     put?: never
@@ -615,7 +615,7 @@ export interface components {
     }
     /** @description ベンチマークのスコア */
     BenchScore: {
-      benchmarkId?: components['schemas']['BenchmarkId']
+      benchmarkId: components['schemas']['BenchmarkId']
       teamId: components['schemas']['TeamId']
       score: components['schemas']['Score']
       createdAt: components['schemas']['CreatedAt']

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -1124,6 +1124,7 @@ components:
         createdAt:
           $ref: "#/components/schemas/CreatedAt"
       required:
+        - benchmarkId
         - teamId
         - score
         - createdAt

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -568,7 +568,7 @@ paths:
     get:
       tags: ["score"]
       summary: "全てのスコア取得"
-      description: "全てのベンチマークのスコアをチームごとに取得します (0件の場合も200で空配列が返ります)"
+      description: "全てのベンチマークのスコアをチームごとに取得します (0件の場合も200で空配列が返ります)。スコアは古い順に並んでいます。チームの順番は任意です。"
       operationId: "getScores"
       security:
         - UserAuth: []

--- a/server/domain/score.go
+++ b/server/domain/score.go
@@ -1,0 +1,14 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Score struct {
+	BenchmarkID uuid.UUID
+	TeamID      uuid.UUID
+	Score       int64
+	CreatedAt   time.Time
+}

--- a/server/handler/openapi/oas_json_gen.go
+++ b/server/handler/openapi/oas_json_gen.go
@@ -25,10 +25,8 @@ func (s *BenchScore) Encode(e *jx.Encoder) {
 // encodeFields encodes fields.
 func (s *BenchScore) encodeFields(e *jx.Encoder) {
 	{
-		if s.BenchmarkId.Set {
-			e.FieldStart("benchmarkId")
-			s.BenchmarkId.Encode(e)
-		}
+		e.FieldStart("benchmarkId")
+		s.BenchmarkId.Encode(e)
 	}
 	{
 		e.FieldStart("teamId")
@@ -61,8 +59,8 @@ func (s *BenchScore) Decode(d *jx.Decoder) error {
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
 		case "benchmarkId":
+			requiredBitSet[0] |= 1 << 0
 			if err := func() error {
-				s.BenchmarkId.Reset()
 				if err := s.BenchmarkId.Decode(d); err != nil {
 					return err
 				}
@@ -110,7 +108,7 @@ func (s *BenchScore) Decode(d *jx.Decoder) error {
 	// Validate required fields.
 	var failures []validate.FieldError
 	for i, mask := range [1]uint8{
-		0b00001110,
+		0b00001111,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -2692,39 +2690,6 @@ func (s *NotFound) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *NotFound) UnmarshalJSON(data []byte) error {
-	d := jx.DecodeBytes(data)
-	return s.Decode(d)
-}
-
-// Encode encodes BenchmarkId as json.
-func (o OptBenchmarkId) Encode(e *jx.Encoder) {
-	if !o.Set {
-		return
-	}
-	o.Value.Encode(e)
-}
-
-// Decode decodes BenchmarkId from json.
-func (o *OptBenchmarkId) Decode(d *jx.Decoder) error {
-	if o == nil {
-		return errors.New("invalid: unable to decode OptBenchmarkId to nil")
-	}
-	o.Set = true
-	if err := o.Value.Decode(d); err != nil {
-		return err
-	}
-	return nil
-}
-
-// MarshalJSON implements stdjson.Marshaler.
-func (s OptBenchmarkId) MarshalJSON() ([]byte, error) {
-	e := jx.Encoder{}
-	s.Encode(&e)
-	return e.Bytes(), nil
-}
-
-// UnmarshalJSON implements stdjson.Unmarshaler.
-func (s *OptBenchmarkId) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/server/handler/openapi/oas_schemas_gen.go
+++ b/server/handler/openapi/oas_schemas_gen.go
@@ -27,14 +27,14 @@ func (s *AdminAuth) SetAPIKey(val string) {
 // ベンチマークのスコア.
 // Ref: #/components/schemas/BenchScore
 type BenchScore struct {
-	BenchmarkId OptBenchmarkId `json:"benchmarkId"`
-	TeamId      TeamId         `json:"teamId"`
-	Score       Score          `json:"score"`
-	CreatedAt   CreatedAt      `json:"createdAt"`
+	BenchmarkId BenchmarkId `json:"benchmarkId"`
+	TeamId      TeamId      `json:"teamId"`
+	Score       Score       `json:"score"`
+	CreatedAt   CreatedAt   `json:"createdAt"`
 }
 
 // GetBenchmarkId returns the value of BenchmarkId.
-func (s *BenchScore) GetBenchmarkId() OptBenchmarkId {
+func (s *BenchScore) GetBenchmarkId() BenchmarkId {
 	return s.BenchmarkId
 }
 
@@ -54,7 +54,7 @@ func (s *BenchScore) GetCreatedAt() CreatedAt {
 }
 
 // SetBenchmarkId sets the value of BenchmarkId.
-func (s *BenchScore) SetBenchmarkId(val OptBenchmarkId) {
+func (s *BenchScore) SetBenchmarkId(val BenchmarkId) {
 	s.BenchmarkId = val
 }
 
@@ -1132,52 +1132,6 @@ func (*NotFound) getTeamInstancesRes()       {}
 func (*NotFound) getTeamRes()                {}
 func (*NotFound) patchTeamInstanceRes()      {}
 func (*NotFound) patchTeamRes()              {}
-
-// NewOptBenchmarkId returns new OptBenchmarkId with value set to v.
-func NewOptBenchmarkId(v BenchmarkId) OptBenchmarkId {
-	return OptBenchmarkId{
-		Value: v,
-		Set:   true,
-	}
-}
-
-// OptBenchmarkId is optional BenchmarkId.
-type OptBenchmarkId struct {
-	Value BenchmarkId
-	Set   bool
-}
-
-// IsSet returns true if OptBenchmarkId was set.
-func (o OptBenchmarkId) IsSet() bool { return o.Set }
-
-// Reset unsets value.
-func (o *OptBenchmarkId) Reset() {
-	var v BenchmarkId
-	o.Value = v
-	o.Set = false
-}
-
-// SetTo sets value to v.
-func (o *OptBenchmarkId) SetTo(v BenchmarkId) {
-	o.Set = true
-	o.Value = v
-}
-
-// Get returns value and boolean that denotes whether value was set.
-func (o OptBenchmarkId) Get() (v BenchmarkId, ok bool) {
-	if !o.Set {
-		return v, false
-	}
-	return o.Value, true
-}
-
-// Or returns value if set, or given parameter if does not.
-func (o OptBenchmarkId) Or(d BenchmarkId) BenchmarkId {
-	if v, ok := o.Get(); ok {
-		return v
-	}
-	return d
-}
 
 // NewOptBenchmarkStatus returns new OptBenchmarkStatus with value set to v.
 func NewOptBenchmarkStatus(v BenchmarkStatus) OptBenchmarkStatus {

--- a/server/handler/score.go
+++ b/server/handler/score.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/piscon-portal-v2/server/domain"
+	"github.com/traPtitech/piscon-portal-v2/server/handler/openapi"
+)
+
+func (h *Handler) GetScores(c echo.Context) error {
+	teamScores, err := h.useCase.GetScores(c.Request().Context())
+	if err != nil {
+		return internalServerErrorResponse(c, err)
+	}
+
+	res := make([]openapi.TeamScores, 0, len(teamScores))
+	for _, teamScore := range teamScores {
+		scores := make([]openapi.BenchScore, 0, len(teamScore.Scores))
+		for _, score := range teamScore.Scores {
+			scores = append(scores, toBenchScore(score))
+		}
+
+		res = append(res, openapi.TeamScores{
+			TeamId: openapi.TeamId(teamScore.TeamID),
+			Scores: scores,
+		})
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+func toBenchScore(score domain.Score) openapi.BenchScore {
+	return openapi.BenchScore{
+		BenchmarkId: openapi.BenchmarkId(score.BenchmarkID),
+		TeamId:      openapi.TeamId(score.TeamID),
+		Score:       openapi.Score(score.Score),
+		CreatedAt:   openapi.CreatedAt(score.CreatedAt),
+	}
+}

--- a/server/handler/score_test.go
+++ b/server/handler/score_test.go
@@ -1,0 +1,152 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/piscon-portal-v2/server/domain"
+	"github.com/traPtitech/piscon-portal-v2/server/handler/openapi"
+	repomock "github.com/traPtitech/piscon-portal-v2/server/repository/mock"
+	"github.com/traPtitech/piscon-portal-v2/server/usecase"
+	usecasemock "github.com/traPtitech/piscon-portal-v2/server/usecase/mock"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetScores(t *testing.T) {
+	t.Parallel()
+
+	teamID1 := uuid.New()
+	teamScores1 := usecase.TeamScores{
+		TeamID: teamID1,
+		Scores: []domain.Score{
+			{BenchmarkID: uuid.New(), TeamID: teamID1, Score: 100, CreatedAt: time.Now()},
+		},
+	}
+	openapiTeamScores1 := openapi.GetScoresOKApplicationJSON{openapi.TeamScores{
+		TeamId: openapi.TeamId(teamID1),
+		Scores: []openapi.BenchScore{
+			{
+				BenchmarkId: openapi.BenchmarkId(teamScores1.Scores[0].BenchmarkID),
+				TeamId:      openapi.TeamId(teamScores1.Scores[0].TeamID),
+				Score:       openapi.Score(teamScores1.Scores[0].Score),
+				CreatedAt:   openapi.CreatedAt(teamScores1.Scores[0].CreatedAt),
+			},
+		},
+	}}
+
+	teamID2 := uuid.New()
+	teamScores2 := usecase.TeamScores{
+		TeamID: teamID2,
+		Scores: []domain.Score{
+			{BenchmarkID: uuid.New(), TeamID: teamID2, Score: 200, CreatedAt: time.Now()},
+			{BenchmarkID: uuid.New(), TeamID: teamID2, Score: 300, CreatedAt: time.Now()},
+		},
+	}
+	openapiTeamScores2 := openapi.GetScoresOKApplicationJSON{
+		{
+			TeamId: openapi.TeamId(teamID1),
+			Scores: []openapi.BenchScore{
+				{
+					BenchmarkId: openapi.BenchmarkId(teamScores1.Scores[0].BenchmarkID),
+					TeamId:      openapi.TeamId(teamScores1.Scores[0].TeamID),
+					Score:       openapi.Score(teamScores1.Scores[0].Score),
+					CreatedAt:   openapi.CreatedAt(teamScores1.Scores[0].CreatedAt),
+				},
+			},
+		},
+		{
+			TeamId: openapi.TeamId(teamID2),
+			Scores: []openapi.BenchScore{
+				{
+					BenchmarkId: openapi.BenchmarkId(teamScores2.Scores[0].BenchmarkID),
+					TeamId:      openapi.TeamId(teamScores2.Scores[0].TeamID),
+					Score:       openapi.Score(teamScores2.Scores[0].Score),
+					CreatedAt:   openapi.CreatedAt(teamScores2.Scores[0].CreatedAt),
+				},
+				{
+					BenchmarkId: openapi.BenchmarkId(teamScores2.Scores[1].BenchmarkID),
+					TeamId:      openapi.TeamId(teamScores2.Scores[1].TeamID),
+					Score:       openapi.Score(teamScores2.Scores[1].Score),
+					CreatedAt:   openapi.CreatedAt(teamScores2.Scores[1].CreatedAt),
+				},
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		teamScores   []usecase.TeamScores
+		GetScoresErr error
+		resBosy      openapi.GetScoresOKApplicationJSON
+		code         int
+	}{
+		"GetScoresがエラーなので500": {
+			teamScores:   nil,
+			GetScoresErr: assert.AnError,
+			code:         http.StatusInternalServerError,
+		},
+		"何もない": {
+			teamScores: []usecase.TeamScores{},
+			code:       http.StatusOK,
+		},
+		"GetScoresが1件": {
+			teamScores: []usecase.TeamScores{teamScores1},
+			code:       http.StatusOK,
+			resBosy:    openapiTeamScores1,
+		},
+		"GetScoresが複数件": {
+			teamScores: []usecase.TeamScores{teamScores1, teamScores2},
+			code:       http.StatusOK,
+			resBosy:    openapiTeamScores2,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+
+			repoMock := repomock.NewMockRepository(ctrl)
+			useCaseMock := usecasemock.NewMockUseCase(ctrl)
+
+			e := echo.New()
+			h := NewHandler(useCaseMock, repoMock, nil)
+
+			req := httptest.NewRequest(http.MethodGet, "/scores", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			useCaseMock.EXPECT().GetScores(gomock.Any()).Return(testCase.teamScores, testCase.GetScoresErr)
+
+			_ = h.GetScores(c)
+
+			assert.Equal(t, testCase.code, rec.Code)
+
+			if rec.Code != http.StatusOK {
+				return
+			}
+
+			var resBody openapi.GetScoresOKApplicationJSON
+			err := json.Unmarshal(rec.Body.Bytes(), &resBody)
+			assert.NoError(t, err)
+			assert.Equal(t, len(testCase.teamScores), len(resBody))
+			for i, teamScore := range testCase.teamScores {
+				assert.Equal(t, teamScore.TeamID, uuid.UUID(resBody[i].TeamId))
+				assert.Equal(t, len(teamScore.Scores), len(resBody[i].Scores))
+				for j, score := range teamScore.Scores {
+					assert.Equal(t, score.BenchmarkID, uuid.UUID(resBody[i].Scores[j].BenchmarkId))
+					assert.Equal(t, score.TeamID, uuid.UUID(resBody[i].Scores[j].TeamId))
+					assert.Equal(t, score.Score, int64(resBody[i].Scores[j].Score))
+					assert.WithinDuration(t, score.CreatedAt, time.Time(resBody[i].Scores[j].CreatedAt), time.Second)
+				}
+			}
+
+		})
+	}
+}

--- a/server/usecase/mock/usecase.go
+++ b/server/usecase/mock/usecase.go
@@ -316,6 +316,45 @@ func (c *MockUseCaseGetQueuedBenchmarksCall) DoAndReturn(f func(context.Context)
 	return c
 }
 
+// GetScores mocks base method.
+func (m *MockUseCase) GetScores(ctx context.Context) ([]usecase.TeamScores, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetScores", ctx)
+	ret0, _ := ret[0].([]usecase.TeamScores)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetScores indicates an expected call of GetScores.
+func (mr *MockUseCaseMockRecorder) GetScores(ctx any) *MockUseCaseGetScoresCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetScores", reflect.TypeOf((*MockUseCase)(nil).GetScores), ctx)
+	return &MockUseCaseGetScoresCall{Call: call}
+}
+
+// MockUseCaseGetScoresCall wrap *gomock.Call
+type MockUseCaseGetScoresCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockUseCaseGetScoresCall) Return(arg0 []usecase.TeamScores, arg1 error) *MockUseCaseGetScoresCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockUseCaseGetScoresCall) Do(f func(context.Context) ([]usecase.TeamScores, error)) *MockUseCaseGetScoresCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockUseCaseGetScoresCall) DoAndReturn(f func(context.Context) ([]usecase.TeamScores, error)) *MockUseCaseGetScoresCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetTeam mocks base method.
 func (m *MockUseCase) GetTeam(ctx context.Context, id uuid.UUID) (domain.Team, error) {
 	m.ctrl.T.Helper()

--- a/server/usecase/score.go
+++ b/server/usecase/score.go
@@ -1,0 +1,64 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/traPtitech/piscon-portal-v2/server/domain"
+	"github.com/traPtitech/piscon-portal-v2/server/repository"
+	"github.com/traPtitech/piscon-portal-v2/server/utils/optional"
+)
+
+type TeamScores struct {
+	TeamID uuid.UUID
+	Scores []domain.Score
+}
+
+type ScoreUseCase interface {
+	// GetScores は、チームごとのベンチマークのスコアを取得する。
+	// それぞれのチームのScoresは古い順に並んでいる。
+	// チームの順番は任意
+	GetScores(ctx context.Context) ([]TeamScores, error)
+}
+
+type scoreUseCaseImpl struct {
+	repo repository.Repository
+}
+
+func NewScoreUseCase(repo repository.Repository) ScoreUseCase {
+	return &scoreUseCaseImpl{repo: repo}
+}
+
+func (u *scoreUseCaseImpl) GetScores(ctx context.Context) ([]TeamScores, error) {
+	benchmarks, err := u.repo.GetBenchmarks(ctx, repository.BenchmarkQuery{
+		StatusIn: optional.From([]domain.BenchmarkStatus{domain.BenchmarkStatusFinished}),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get benchmarks: %w", err)
+	}
+
+	teamScores := make(map[uuid.UUID][]domain.Score, 10) // 長さが分からないので適当な値
+	for _, benchmark := range benchmarks {
+		if _, ok := teamScores[benchmark.TeamID]; !ok {
+			teamScores[benchmark.TeamID] = make([]domain.Score, 0, 5) // 長さが分からないので適当な値
+		}
+
+		teamScores[benchmark.TeamID] = append(teamScores[benchmark.TeamID], domain.Score{
+			BenchmarkID: benchmark.ID,
+			TeamID:      benchmark.TeamID,
+			Score:       benchmark.Score,
+			CreatedAt:   benchmark.CreatedAt,
+		})
+	}
+
+	teamScoreList := make([]TeamScores, 0, len(teamScores))
+	for teamID, scores := range teamScores {
+		teamScoreList = append(teamScoreList, TeamScores{
+			TeamID: teamID,
+			Scores: scores,
+		})
+	}
+
+	return teamScoreList, nil
+}

--- a/server/usecase/score_test.go
+++ b/server/usecase/score_test.go
@@ -1,0 +1,129 @@
+package usecase_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/piscon-portal-v2/server/domain"
+	"github.com/traPtitech/piscon-portal-v2/server/repository"
+	"github.com/traPtitech/piscon-portal-v2/server/repository/mock"
+	"github.com/traPtitech/piscon-portal-v2/server/usecase"
+	"github.com/traPtitech/piscon-portal-v2/server/utils/optional"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetScores(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	teamID1 := uuid.New()
+	bench1 := domain.Benchmark{
+		ID:        uuid.New(),
+		TeamID:    teamID1,
+		Score:     100,
+		CreatedAt: now.Add(-time.Hour),
+		Status:    domain.BenchmarkStatusFinished,
+	}
+	bench2 := domain.Benchmark{
+		ID:        uuid.New(),
+		TeamID:    teamID1,
+		Score:     200,
+		CreatedAt: now.Add(-time.Minute),
+		Status:    domain.BenchmarkStatusFinished,
+	}
+	teamID2 := uuid.New()
+	bench3 := domain.Benchmark{
+		ID:        uuid.New(),
+		TeamID:    teamID2,
+		Score:     300,
+		CreatedAt: now.Add(-time.Minute * 30),
+		Status:    domain.BenchmarkStatusFinished,
+	}
+	bench4 := domain.Benchmark{
+		ID:        uuid.New(),
+		TeamID:    teamID2,
+		Score:     400,
+		CreatedAt: now,
+		Status:    domain.BenchmarkStatusFinished,
+	}
+
+	testCases := map[string]struct {
+		benchmarks       []domain.Benchmark
+		GetBenchmarksErr error
+		want             []usecase.TeamScores
+		wantErr          error
+	}{
+		"GetBenchmarksがエラーなのでエラー": {
+			GetBenchmarksErr: assert.AnError,
+			wantErr:          assert.AnError,
+		},
+		"GetBenchmarksが空のスライスを返す": {
+			benchmarks: []domain.Benchmark{},
+			want:       []usecase.TeamScores{},
+		},
+		"正しくスコアを取得できる": {
+			benchmarks: []domain.Benchmark{bench1, bench2, bench3, bench4},
+			want: []usecase.TeamScores{
+				{
+					TeamID: teamID1,
+					Scores: []domain.Score{
+						{BenchmarkID: bench1.ID, TeamID: teamID1, Score: bench1.Score, CreatedAt: bench1.CreatedAt},
+						{BenchmarkID: bench2.ID, TeamID: teamID1, Score: bench2.Score, CreatedAt: bench2.CreatedAt},
+					},
+				},
+				{
+					TeamID: teamID2,
+					Scores: []domain.Score{
+						{BenchmarkID: bench3.ID, TeamID: teamID2, Score: bench3.Score, CreatedAt: bench3.CreatedAt},
+						{BenchmarkID: bench4.ID, TeamID: teamID2, Score: bench4.Score, CreatedAt: bench4.CreatedAt},
+					},
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			r := mock.NewMockRepository(ctrl)
+
+			r.EXPECT().
+				GetBenchmarks(gomock.Any(), repository.BenchmarkQuery{
+					StatusIn: optional.From([]domain.BenchmarkStatus{domain.BenchmarkStatusFinished}),
+				}).
+				Return(testCase.benchmarks, testCase.GetBenchmarksErr)
+
+			s := usecase.NewScoreUseCase(r)
+
+			got, err := s.GetScores(t.Context())
+
+			if testCase.wantErr != nil {
+				assert.ErrorIs(t, err, testCase.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, len(testCase.want), len(got))
+
+			wantScoresMap := make(map[uuid.UUID][]domain.Score, len(testCase.want))
+			for _, teamScore := range testCase.want {
+				wantScoresMap[teamScore.TeamID] = teamScore.Scores
+			}
+
+			for _, gotTeamScore := range got {
+				wantScores, ok := wantScoresMap[gotTeamScore.TeamID]
+				assert.True(t, ok)
+
+				assert.Equal(t, wantScores, gotTeamScore.Scores)
+			}
+		})
+	}
+}

--- a/server/usecase/usecase.go
+++ b/server/usecase/usecase.go
@@ -9,12 +9,14 @@ type UseCase interface {
 	TeamUseCase
 	UserUseCase
 	BenchmarkUseCase
+	ScoreUseCase
 }
 
 type useCaseImpl struct {
 	TeamUseCase
 	UserUseCase
 	BenchmarkUseCase
+	ScoreUseCase
 }
 
 func New(repo repository.Repository) UseCase {
@@ -22,5 +24,6 @@ func New(repo repository.Repository) UseCase {
 		TeamUseCase:      NewTeamUseCase(repo),
 		UserUseCase:      NewUserUseCase(repo),
 		BenchmarkUseCase: NewBenchmarkUseCase(repo),
+		ScoreUseCase:     NewScoreUseCase(repo),
 	}
 }


### PR DESCRIPTION
- **:memo: OpenAPIに順番の説明追加**
- **:adhesive_bandage: domainにscore.goを追加**
- **:sparkles: usecaseでGetScoresを実装**
- **:adhesive_bandage: benchmarkIdをrequiredにする**
- **:factory: OpenAPIのコード生成**
- **:adhesive_bandage: usecaseにScoreUseCaseを追加**
- **:factory: mockの生成**
- **:sparkles: handlerのGetScoresを実装**
