### PR TITLE
`PUT /admins` の実装

### DIFF
--- a/server/handler/admin.go
+++ b/server/handler/admin.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/traPtitech/piscon-portal-v2/server/usecase"
+)
+
+func (h *Handler) PutAdmins(c echo.Context) error {
+	var req []string
+	err := json.NewDecoder(c.Request().Body).Decode(&req)
+	if err != nil {
+		return badRequestResponse(c, "invalid request body")
+	}
+	defer c.Request().Body.Close()
+
+	ids := make([]uuid.UUID, 0, len(req))
+	for _, id := range req {
+		uuid, err := uuid.Parse(id)
+		if err != nil {
+			return badRequestResponse(c, fmt.Sprintf("invalid uuid: '%s'", id))
+		}
+		ids = append(ids, uuid)
+	}
+
+	loginUserID := getUserIDFromSession(c)
+
+	err = h.useCase.PutAdmins(c.Request().Context(), loginUserID, ids)
+	if usecase.IsUseCaseError(err) {
+		return badRequestResponse(c, err.Error())
+	}
+	if err != nil {
+		return internalServerErrorResponse(c, err)
+	}
+
+	return c.NoContent(http.StatusOK)
+}

--- a/server/handler/admin_test.go
+++ b/server/handler/admin_test.go
@@ -1,0 +1,94 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traPtitech/piscon-portal-v2/server/handler"
+	repomock "github.com/traPtitech/piscon-portal-v2/server/repository/mock"
+	"github.com/traPtitech/piscon-portal-v2/server/usecase"
+	usecasemock "github.com/traPtitech/piscon-portal-v2/server/usecase/mock"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPutAdmins(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	type PutAdminsResult struct {
+		err error
+	}
+
+	userID := uuid.New()
+
+	testCases := map[string]struct {
+		reqBody         []string
+		loginUserID     uuid.UUID
+		PutAdminsResult *PutAdminsResult
+		expectedStatus  int
+	}{
+		"無効なuuidが含まれているので400": {
+			reqBody:        []string{"invalid-uuid"},
+			loginUserID:    uuid.New(),
+			expectedStatus: http.StatusBadRequest,
+		},
+		"PutAdminsでエラーが発生したので500": {
+			reqBody:         []string{userID.String()},
+			loginUserID:     uuid.New(),
+			PutAdminsResult: &PutAdminsResult{err: assert.AnError},
+			expectedStatus:  http.StatusInternalServerError,
+		},
+		"PutAdminsでUseCaseErrorが発生したので400": {
+			reqBody:         []string{userID.String()},
+			loginUserID:     uuid.New(),
+			PutAdminsResult: &PutAdminsResult{err: usecase.NewUseCaseError(assert.AnError)},
+			expectedStatus:  http.StatusBadRequest,
+		},
+		"正常系": {
+			reqBody:         []string{userID.String()},
+			loginUserID:     uuid.New(),
+			PutAdminsResult: &PutAdminsResult{},
+			expectedStatus:  http.StatusOK,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repoMock := repomock.NewMockRepository(ctrl)
+			useCaseMock := usecasemock.NewMockUseCase(ctrl)
+
+			if testCase.PutAdminsResult != nil {
+				useCaseMock.EXPECT().
+					PutAdmins(gomock.Any(), testCase.loginUserID, []uuid.UUID{userID}).
+					Return(testCase.PutAdminsResult.err)
+			}
+
+			e := echo.New()
+
+			bodyJSON, err := json.Marshal(testCase.reqBody)
+			require.NoError(t, err)
+			body := bytes.NewBuffer(bodyJSON)
+
+			req := httptest.NewRequest(http.MethodGet, "/admins", body)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.Set(handler.UserIDKey, testCase.loginUserID)
+			h := NewHandler(useCaseMock, repoMock, nil)
+
+			_ = h.PutAdmins(c)
+
+			assert.Equal(t, testCase.expectedStatus, rec.Code)
+		})
+	}
+
+}

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -81,4 +81,7 @@ func (h *Handler) SetupRoutes(e *echo.Echo) {
 	scores := api.Group("/scores", h.AuthMiddleware())
 	scores.GET("", h.GetScores)
 	scores.GET("/ranking", h.GetRanking)
+
+	admins := api.Group("/admins", h.AdminAuthMiddleware())
+	admins.PUT("", h.PutAdmins)
 }

--- a/server/repository/db/user.go
+++ b/server/repository/db/user.go
@@ -92,6 +92,26 @@ func (r *Repository) GetUsersByIDs(ctx context.Context, ids []uuid.UUID) ([]doma
 	return res, nil
 }
 
+func (r *Repository) GetAdmins(ctx context.Context) ([]domain.User, error) {
+	adminUsers, err := models.Users.Query(
+		sm.Where(models.UserColumns.IsAdmin.EQ(mysql.Arg(true))),
+	).All(ctx, r.executor(ctx))
+	if err != nil {
+		return nil, fmt.Errorf("get admins: %w", err)
+	}
+
+	res := make([]domain.User, 0, len(adminUsers))
+	for _, user := range adminUsers {
+		domainUser, err := toDomainUser(user)
+		if err != nil {
+			return nil, fmt.Errorf("convert user: %w", err)
+		}
+		res = append(res, domainUser)
+	}
+
+	return res, nil
+}
+
 func toDomainUser(user *models.User) (domain.User, error) {
 	userID, err := uuid.Parse(user.ID)
 	if err != nil {

--- a/server/repository/db/user.go
+++ b/server/repository/db/user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stephenafamo/bob"
 	"github.com/stephenafamo/bob/dialect/mysql"
 	"github.com/stephenafamo/bob/dialect/mysql/sm"
+	"github.com/stephenafamo/bob/dialect/mysql/um"
 	"github.com/traPtitech/piscon-portal-v2/server/domain"
 	"github.com/traPtitech/piscon-portal-v2/server/repository"
 	"github.com/traPtitech/piscon-portal-v2/server/repository/db/models"
@@ -110,6 +111,26 @@ func (r *Repository) GetAdmins(ctx context.Context) ([]domain.User, error) {
 	}
 
 	return res, nil
+}
+
+func (r *Repository) AddAdmins(ctx context.Context, userIDs []uuid.UUID) error {
+	if len(userIDs) == 0 {
+		return nil
+	}
+
+	anyIDs := make([]any, len(userIDs))
+	for i, id := range userIDs {
+		anyIDs[i] = id.String()
+	}
+	_, err := models.Users.Update(
+		um.SetCol(models.ColumnNames.Users.IsAdmin).To(true),
+		um.Where(models.UserColumns.ID.In(mysql.Arg(anyIDs...))),
+	).Exec(ctx, r.executor(ctx))
+	if err != nil {
+		return fmt.Errorf("add admins: %w", err)
+	}
+
+	return nil
 }
 
 func toDomainUser(user *models.User) (domain.User, error) {

--- a/server/repository/db/user.go
+++ b/server/repository/db/user.go
@@ -133,6 +133,26 @@ func (r *Repository) AddAdmins(ctx context.Context, userIDs []uuid.UUID) error {
 	return nil
 }
 
+func (r *Repository) DeleteAdmins(ctx context.Context, userIDs []uuid.UUID) error {
+	if len(userIDs) == 0 {
+		return nil
+	}
+
+	anyIDs := make([]any, len(userIDs))
+	for i, id := range userIDs {
+		anyIDs[i] = id.String()
+	}
+	_, err := models.Users.Update(
+		um.SetCol(models.ColumnNames.Users.IsAdmin).To(false),
+		um.Where(models.UserColumns.ID.In(mysql.Arg(anyIDs...))),
+	).Exec(ctx, r.executor(ctx))
+	if err != nil {
+		return fmt.Errorf("delete admins: %w", err)
+	}
+
+	return nil
+}
+
 func toDomainUser(user *models.User) (domain.User, error) {
 	userID, err := uuid.Parse(user.ID)
 	if err != nil {

--- a/server/repository/db/user_test.go
+++ b/server/repository/db/user_test.go
@@ -59,3 +59,69 @@ func TestGetUsers(t *testing.T) {
 
 	testutil.CompareUsers(t, users, got)
 }
+
+func TestGetUsersByIDs(t *testing.T) {
+	t.Parallel()
+
+	repo, db := setupRepository(t)
+	team := domain.NewTeam("team1")
+	userID1, userID2, userID3 := uuid.New(), uuid.New(), uuid.New()
+	user1 := domain.User{
+		ID:     userID1,
+		Name:   "user1",
+		TeamID: uuid.NullUUID{UUID: team.ID, Valid: true},
+	}
+	user2 := domain.User{
+		ID:     userID2,
+		Name:   "user2",
+		TeamID: uuid.NullUUID{UUID: team.ID, Valid: true},
+	}
+	user3 := domain.User{
+		ID:     userID3,
+		Name:   "user3",
+		TeamID: uuid.NullUUID{UUID: team.ID, Valid: true},
+	}
+	users := []domain.User{user1, user2, user3}
+
+	mustMakeTeam(t, db, team)
+	for _, user := range users {
+		mustMakeUser(t, db, user)
+	}
+
+	testCases := map[string]struct {
+		ids   []uuid.UUID
+		users []domain.User
+	}{
+		"idsが空": {},
+		"1つ取得できる": {
+			ids:   []uuid.UUID{userID1},
+			users: []domain.User{user1},
+		},
+		"2つ取得できる": {
+			ids:   []uuid.UUID{userID1, userID2},
+			users: []domain.User{user1, user2},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			users, err := repo.GetUsersByIDs(t.Context(), testCase.ids)
+
+			expectedUsersMap := make(map[uuid.UUID]domain.User, len(testCase.users))
+			for _, user := range testCase.users {
+				expectedUsersMap[user.ID] = user
+			}
+
+			assert.NoError(t, err)
+			assert.Len(t, users, len(testCase.users))
+			for _, user := range users {
+				expectedUser, ok := expectedUsersMap[user.ID]
+				assert.True(t, ok)
+				assert.Equal(t, expectedUser.ID, user.ID)
+				assert.Equal(t, expectedUser.Name, user.Name)
+				assert.Equal(t, expectedUser.TeamID, user.TeamID)
+				assert.Equal(t, expectedUser.IsAdmin, user.IsAdmin)
+			}
+		})
+	}
+}

--- a/server/repository/db/user_test.go
+++ b/server/repository/db/user_test.go
@@ -125,3 +125,28 @@ func TestGetUsersByIDs(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAdmins(t *testing.T) {
+	t.Parallel()
+
+	repo, db := setupRepository(t)
+
+	adminUser := domain.User{
+		ID:      uuid.New(),
+		Name:    "adminUser",
+		IsAdmin: true,
+	}
+	normalUser := domain.User{
+		ID:   uuid.New(),
+		Name: "normalUser",
+	}
+	mustMakeUser(t, db, adminUser)
+	mustMakeUser(t, db, normalUser)
+
+	got, err := repo.GetAdmins(t.Context())
+	assert.NoError(t, err)
+	assert.Len(t, got, 1)
+	assert.Equal(t, adminUser.ID, got[0].ID)
+	assert.Equal(t, adminUser.Name, got[0].Name)
+	assert.Equal(t, adminUser.IsAdmin, got[0].IsAdmin)
+}

--- a/server/repository/db/util_test.go
+++ b/server/repository/db/util_test.go
@@ -18,9 +18,10 @@ import (
 func mustMakeUser(t *testing.T, executor bob.Executor, user domain.User) {
 	t.Helper()
 	_, err := models.Users.Insert(&models.UserSetter{
-		ID:     omit.From(user.ID.String()),
-		Name:   omit.From(user.Name),
-		TeamID: lo.Ternary(user.TeamID.Valid, omitnull.From(user.TeamID.UUID.String()), omitnull.Val[string]{}),
+		ID:      omit.From(user.ID.String()),
+		Name:    omit.From(user.Name),
+		TeamID:  lo.Ternary(user.TeamID.Valid, omitnull.From(user.TeamID.UUID.String()), omitnull.Val[string]{}),
+		IsAdmin: omit.From(user.IsAdmin),
 	}).Exec(context.Background(), executor)
 	require.NoError(t, err)
 }

--- a/server/repository/mock/repository.go
+++ b/server/repository/mock/repository.go
@@ -43,6 +43,44 @@ func (m *MockRepository) EXPECT() *MockRepositoryMockRecorder {
 	return m.recorder
 }
 
+// AddAdmins mocks base method.
+func (m *MockRepository) AddAdmins(ctx context.Context, userIDs []uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddAdmins", ctx, userIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddAdmins indicates an expected call of AddAdmins.
+func (mr *MockRepositoryMockRecorder) AddAdmins(ctx, userIDs any) *MockRepositoryAddAdminsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAdmins", reflect.TypeOf((*MockRepository)(nil).AddAdmins), ctx, userIDs)
+	return &MockRepositoryAddAdminsCall{Call: call}
+}
+
+// MockRepositoryAddAdminsCall wrap *gomock.Call
+type MockRepositoryAddAdminsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryAddAdminsCall) Return(arg0 error) *MockRepositoryAddAdminsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryAddAdminsCall) Do(f func(context.Context, []uuid.UUID) error) *MockRepositoryAddAdminsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryAddAdminsCall) DoAndReturn(f func(context.Context, []uuid.UUID) error) *MockRepositoryAddAdminsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateBenchmark mocks base method.
 func (m *MockRepository) CreateBenchmark(ctx context.Context, benchmark domain.Benchmark) error {
 	m.ctrl.T.Helper()
@@ -229,6 +267,44 @@ func (c *MockRepositoryCreateUserCall) Do(f func(context.Context, domain.User) e
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockRepositoryCreateUserCall) DoAndReturn(f func(context.Context, domain.User) error) *MockRepositoryCreateUserCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DeleteAdmins mocks base method.
+func (m *MockRepository) DeleteAdmins(ctx context.Context, userIDs []uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAdmins", ctx, userIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAdmins indicates an expected call of DeleteAdmins.
+func (mr *MockRepositoryMockRecorder) DeleteAdmins(ctx, userIDs any) *MockRepositoryDeleteAdminsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAdmins", reflect.TypeOf((*MockRepository)(nil).DeleteAdmins), ctx, userIDs)
+	return &MockRepositoryDeleteAdminsCall{Call: call}
+}
+
+// MockRepositoryDeleteAdminsCall wrap *gomock.Call
+type MockRepositoryDeleteAdminsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryDeleteAdminsCall) Return(arg0 error) *MockRepositoryDeleteAdminsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryDeleteAdminsCall) Do(f func(context.Context, []uuid.UUID) error) *MockRepositoryDeleteAdminsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryDeleteAdminsCall) DoAndReturn(f func(context.Context, []uuid.UUID) error) *MockRepositoryDeleteAdminsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -462,6 +538,45 @@ func (c *MockRepositoryFindUserCall) Do(f func(context.Context, uuid.UUID) (doma
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockRepositoryFindUserCall) DoAndReturn(f func(context.Context, uuid.UUID) (domain.User, error)) *MockRepositoryFindUserCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetAdmins mocks base method.
+func (m *MockRepository) GetAdmins(ctx context.Context) ([]domain.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdmins", ctx)
+	ret0, _ := ret[0].([]domain.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAdmins indicates an expected call of GetAdmins.
+func (mr *MockRepositoryMockRecorder) GetAdmins(ctx any) *MockRepositoryGetAdminsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdmins", reflect.TypeOf((*MockRepository)(nil).GetAdmins), ctx)
+	return &MockRepositoryGetAdminsCall{Call: call}
+}
+
+// MockRepositoryGetAdminsCall wrap *gomock.Call
+type MockRepositoryGetAdminsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryGetAdminsCall) Return(arg0 []domain.User, arg1 error) *MockRepositoryGetAdminsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryGetAdminsCall) Do(f func(context.Context) ([]domain.User, error)) *MockRepositoryGetAdminsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryGetAdminsCall) DoAndReturn(f func(context.Context) ([]domain.User, error)) *MockRepositoryGetAdminsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -774,6 +889,45 @@ func (c *MockRepositoryGetUsersCall) Do(f func(context.Context) ([]domain.User, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockRepositoryGetUsersCall) DoAndReturn(f func(context.Context) ([]domain.User, error)) *MockRepositoryGetUsersCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUsersByIDs mocks base method.
+func (m *MockRepository) GetUsersByIDs(ctx context.Context, ids []uuid.UUID) ([]domain.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsersByIDs", ctx, ids)
+	ret0, _ := ret[0].([]domain.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUsersByIDs indicates an expected call of GetUsersByIDs.
+func (mr *MockRepositoryMockRecorder) GetUsersByIDs(ctx, ids any) *MockRepositoryGetUsersByIDsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersByIDs", reflect.TypeOf((*MockRepository)(nil).GetUsersByIDs), ctx, ids)
+	return &MockRepositoryGetUsersByIDsCall{Call: call}
+}
+
+// MockRepositoryGetUsersByIDsCall wrap *gomock.Call
+type MockRepositoryGetUsersByIDsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryGetUsersByIDsCall) Return(arg0 []domain.User, arg1 error) *MockRepositoryGetUsersByIDsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryGetUsersByIDsCall) Do(f func(context.Context, []uuid.UUID) ([]domain.User, error)) *MockRepositoryGetUsersByIDsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryGetUsersByIDsCall) DoAndReturn(f func(context.Context, []uuid.UUID) ([]domain.User, error)) *MockRepositoryGetUsersByIDsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/server/repository/user.go
+++ b/server/repository/user.go
@@ -14,4 +14,20 @@ type UserRepository interface {
 	GetUsers(ctx context.Context) ([]domain.User, error)
 	// CreateUser creates a user.
 	CreateUser(ctx context.Context, user domain.User) error
+	// GetUsersByIDs returns users by ids.
+	// If the user is not found, it returns an empty slice.
+	// If the ids is empty, it returns an empty slice.
+	GetUsersByIDs(ctx context.Context, ids []uuid.UUID) ([]domain.User, error)
+	// GetAdmins returns all admin users.
+	GetAdmins(ctx context.Context) ([]domain.User, error)
+	// UpdateAdmins updates admin users.
+	// If userIDs contains a id that does not exist, it is ignored.
+	// If userIDs is empty, it does nothing.
+	// If userIDs contains a id that is already an admin, it is ignored.
+	AddAdmins(ctx context.Context, userIDs []uuid.UUID) error
+	// DeleteAdmins deletes admin users.
+	// If userIDs contains a id that does not exist, it is ignored.
+	// If userIDs is empty, it does nothing.
+	// If userIDs contains a id that is not an admin, it is ignored.
+	DeleteAdmins(ctx context.Context, userIDs []uuid.UUID) error
 }

--- a/server/usecase/admin.go
+++ b/server/usecase/admin.go
@@ -1,0 +1,87 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/google/uuid"
+	"github.com/traPtitech/piscon-portal-v2/server/repository"
+)
+
+type AdminUseCase interface {
+	// PutAdmins は、管理者の編集をする。
+	// 以下の場合、UseCaseErrorを返し、登録は行われない
+	//  - userIDsの長さが0
+	//  - userIDsに重複がある
+	//  - userIDsに、未ログインのユーザーが含まれる
+	//  - userIDsに、リクエストを行ったユーザー(loginUserID)が含まれない
+	PutAdmins(ctx context.Context, loginUserID uuid.UUID, userIDs []uuid.UUID) error
+}
+
+type adminUseCaseImpl struct {
+	repo repository.Repository
+}
+
+func NewAdminUseCase(repo repository.Repository) AdminUseCase {
+	return &adminUseCaseImpl{repo: repo}
+}
+
+func (u *adminUseCaseImpl) PutAdmins(ctx context.Context, loginUserID uuid.UUID, userIDs []uuid.UUID) error {
+	if len(userIDs) == 0 {
+		return NewUseCaseErrorFromMsg("userIDs is empty")
+	}
+	if len(userIDs) != len(slices.Compact(userIDs)) {
+		return NewUseCaseErrorFromMsg("userIDs has duplicates")
+	}
+	if !slices.Contains(userIDs, loginUserID) {
+		return NewUseCaseErrorFromMsg("login user is not in new admin userIDs")
+	}
+
+	newAdminUserIDsMap := make(map[uuid.UUID]struct{}, len(userIDs))
+	for _, userID := range userIDs {
+		newAdminUserIDsMap[userID] = struct{}{}
+	}
+
+	err := u.repo.Transaction(ctx, func(ctx context.Context) error {
+		newAdminUsers, err := u.repo.GetUsersByIDs(ctx, userIDs)
+		if err != nil {
+			return fmt.Errorf("get users by ids: %w", err)
+		}
+
+		if len(newAdminUsers) != len(userIDs) {
+			return NewUseCaseErrorFromMsg("some userIDs are not logged in")
+		}
+
+		currentAdminUsers, err := u.repo.GetAdmins(ctx)
+		if err != nil {
+			return fmt.Errorf("get admins: %w", err)
+		}
+
+		deletedAdmins := make([]uuid.UUID, 0, len(currentAdminUsers))
+		// 現在はadminで、adminから外れるユーザーを取得
+		for _, admin := range currentAdminUsers {
+			if _, ok := newAdminUserIDsMap[admin.ID]; !ok {
+				deletedAdmins = append(deletedAdmins, admin.ID)
+			}
+		}
+
+		err = u.repo.AddAdmins(ctx, userIDs)
+		if err != nil {
+			return fmt.Errorf("add admins: %w", err)
+		}
+
+		err = u.repo.DeleteAdmins(ctx, deletedAdmins)
+		if err != nil {
+			return fmt.Errorf("delete admins: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("transaction: %w", err)
+	}
+
+	return nil
+}

--- a/server/usecase/admin_test.go
+++ b/server/usecase/admin_test.go
@@ -1,0 +1,173 @@
+package usecase_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/piscon-portal-v2/server/domain"
+	"github.com/traPtitech/piscon-portal-v2/server/repository/mock"
+	"github.com/traPtitech/piscon-portal-v2/server/usecase"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPutAdmins(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	loginUserID := uuid.New()
+	userID1 := uuid.New()
+	userID2 := uuid.New()
+	userID3 := uuid.New()
+
+	loginUser := domain.User{ID: loginUserID}
+	user1 := domain.User{ID: userID1}
+	user2 := domain.User{ID: userID2}
+	user3 := domain.User{ID: userID3}
+
+	type (
+		GetUsersByIDsResult struct {
+			users []domain.User
+			err   error
+		}
+		GetAdminsResult struct {
+			users []domain.User
+			err   error
+		}
+		AddAdminsResult struct {
+			err error
+		}
+		DeleteAdminsResult struct {
+			err error
+		}
+	)
+
+	testCases := map[string]struct {
+		loginUserID         uuid.UUID
+		userIDs             []uuid.UUID
+		execTransaction     bool
+		GetUsersByIDsResult *GetUsersByIDsResult
+		GetAdminsResult     *GetAdminsResult
+		AddAdminsResult     *AddAdminsResult
+		DeleteAdminsResult  *DeleteAdminsResult
+		isUseCaseError      bool
+		err                 error
+	}{
+		"userIDsが空なのでUseCaseError": {
+			loginUserID:    loginUserID,
+			userIDs:        []uuid.UUID{},
+			isUseCaseError: true,
+		},
+		"userIDsに重複があるのでUseCaseError": {
+			loginUserID:    loginUserID,
+			userIDs:        []uuid.UUID{userID1, userID1},
+			isUseCaseError: true,
+		},
+		"loginUserがuserIDsに含まれないのでUseCaseError": {
+			loginUserID:    loginUserID,
+			userIDs:        []uuid.UUID{userID1, userID2},
+			isUseCaseError: true,
+		},
+		"GetUsersByIDsでエラー": {
+			loginUserID:         loginUserID,
+			userIDs:             []uuid.UUID{loginUserID, userID1, userID2},
+			execTransaction:     true,
+			GetUsersByIDsResult: &GetUsersByIDsResult{err: assert.AnError},
+			err:                 assert.AnError,
+		},
+		"GetUsersByIDsでログインしていないユーザーがいるのでUseCaseError": {
+			loginUserID:         loginUserID,
+			userIDs:             []uuid.UUID{loginUserID, userID1, userID2},
+			execTransaction:     true,
+			GetUsersByIDsResult: &GetUsersByIDsResult{users: []domain.User{loginUser, user1}},
+			isUseCaseError:      true,
+		},
+		"GetAdminsでエラー": {
+			loginUserID:         loginUserID,
+			userIDs:             []uuid.UUID{loginUserID, userID1, userID2},
+			execTransaction:     true,
+			GetUsersByIDsResult: &GetUsersByIDsResult{users: []domain.User{loginUser, user1, user2}},
+			GetAdminsResult:     &GetAdminsResult{err: assert.AnError},
+			err:                 assert.AnError,
+		},
+		"AddAdminsでエラー": {
+			loginUserID:         loginUserID,
+			userIDs:             []uuid.UUID{loginUserID, userID1, userID2},
+			execTransaction:     true,
+			GetUsersByIDsResult: &GetUsersByIDsResult{users: []domain.User{loginUser, user1, user2}},
+			GetAdminsResult:     &GetAdminsResult{users: []domain.User{loginUser, user1}},
+			AddAdminsResult:     &AddAdminsResult{err: assert.AnError},
+			err:                 assert.AnError,
+		},
+		"DeleteAdminsでエラー": {
+			loginUserID:         loginUserID,
+			userIDs:             []uuid.UUID{loginUserID, userID1, userID2},
+			execTransaction:     true,
+			GetUsersByIDsResult: &GetUsersByIDsResult{users: []domain.User{loginUser, user1, user2}},
+			GetAdminsResult:     &GetAdminsResult{users: []domain.User{loginUser, user1, user3}},
+			AddAdminsResult:     &AddAdminsResult{},
+			DeleteAdminsResult:  &DeleteAdminsResult{err: assert.AnError},
+			err:                 assert.AnError,
+		},
+		"正常系": {
+			loginUserID:         loginUserID,
+			userIDs:             []uuid.UUID{loginUserID, userID1, userID2},
+			execTransaction:     true,
+			GetUsersByIDsResult: &GetUsersByIDsResult{users: []domain.User{loginUser, user1, user2}},
+			GetAdminsResult:     &GetAdminsResult{users: []domain.User{loginUser, user1, user3}},
+			AddAdminsResult:     &AddAdminsResult{},
+			DeleteAdminsResult:  &DeleteAdminsResult{},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := mock.NewMockRepository(ctrl)
+			uc := usecase.NewAdminUseCase(repo)
+
+			if testCase.execTransaction {
+				repo.EXPECT().Transaction(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, f func(ctx context.Context) error) error { return f(ctx) },
+				)
+			}
+			if testCase.GetUsersByIDsResult != nil {
+				repo.EXPECT().GetUsersByIDs(gomock.Any(), testCase.userIDs).Return(
+					testCase.GetUsersByIDsResult.users, testCase.GetUsersByIDsResult.err,
+				)
+			}
+			if testCase.GetAdminsResult != nil {
+				repo.EXPECT().GetAdmins(gomock.Any()).Return(
+					testCase.GetAdminsResult.users, testCase.GetAdminsResult.err,
+				)
+			}
+			if testCase.AddAdminsResult != nil {
+				repo.EXPECT().AddAdmins(gomock.Any(), testCase.userIDs).Return(testCase.AddAdminsResult.err)
+			}
+			if testCase.DeleteAdminsResult != nil {
+				deletedUserIDs := make([]uuid.UUID, 0, len(testCase.GetAdminsResult.users))
+				for _, admin := range testCase.GetAdminsResult.users {
+					if !slices.Contains(testCase.userIDs, admin.ID) {
+						deletedUserIDs = append(deletedUserIDs, admin.ID)
+					}
+				}
+				repo.EXPECT().DeleteAdmins(gomock.Any(), deletedUserIDs).
+					Return(testCase.DeleteAdminsResult.err)
+			}
+
+			err := uc.PutAdmins(t.Context(), testCase.loginUserID, testCase.userIDs)
+
+			if testCase.isUseCaseError {
+				assert.True(t, usecase.IsUseCaseError(err))
+			} else if testCase.err != nil {
+				assert.ErrorIs(t, err, testCase.err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/server/usecase/mock/usecase.go
+++ b/server/usecase/mock/usecase.go
@@ -589,6 +589,44 @@ func (c *MockUseCaseGetUsersCall) DoAndReturn(f func(context.Context) ([]domain.
 	return c
 }
 
+// PutAdmins mocks base method.
+func (m *MockUseCase) PutAdmins(ctx context.Context, loginUserID uuid.UUID, userIDs []uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutAdmins", ctx, loginUserID, userIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutAdmins indicates an expected call of PutAdmins.
+func (mr *MockUseCaseMockRecorder) PutAdmins(ctx, loginUserID, userIDs any) *MockUseCasePutAdminsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAdmins", reflect.TypeOf((*MockUseCase)(nil).PutAdmins), ctx, loginUserID, userIDs)
+	return &MockUseCasePutAdminsCall{Call: call}
+}
+
+// MockUseCasePutAdminsCall wrap *gomock.Call
+type MockUseCasePutAdminsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockUseCasePutAdminsCall) Return(arg0 error) *MockUseCasePutAdminsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockUseCasePutAdminsCall) Do(f func(context.Context, uuid.UUID, []uuid.UUID) error) *MockUseCasePutAdminsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockUseCasePutAdminsCall) DoAndReturn(f func(context.Context, uuid.UUID, []uuid.UUID) error) *MockUseCasePutAdminsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SaveBenchmarkProgress mocks base method.
 func (m *MockUseCase) SaveBenchmarkProgress(ctx context.Context, benchmarkID uuid.UUID, benchLog domain.BenchmarkLog, score int64, startedAt time.Time) error {
 	m.ctrl.T.Helper()

--- a/server/usecase/usecase.go
+++ b/server/usecase/usecase.go
@@ -10,6 +10,7 @@ type UseCase interface {
 	UserUseCase
 	BenchmarkUseCase
 	ScoreUseCase
+	AdminUseCase
 }
 
 type useCaseImpl struct {
@@ -17,6 +18,7 @@ type useCaseImpl struct {
 	UserUseCase
 	BenchmarkUseCase
 	ScoreUseCase
+	AdminUseCase
 }
 
 func New(repo repository.Repository) UseCase {
@@ -25,5 +27,6 @@ func New(repo repository.Repository) UseCase {
 		UserUseCase:      NewUserUseCase(repo),
 		BenchmarkUseCase: NewBenchmarkUseCase(repo),
 		ScoreUseCase:     NewScoreUseCase(repo),
+		AdminUseCase:     NewAdminUseCase(repo),
 	}
 }


### PR DESCRIPTION
- **:sparkles: usecaseのPutAdminsの実装**
- **:factory: モックの生成**
- **:white_check_mark: usecaseのPutAdminsのテスト**
- **:sparkles: repositoryのGetUsersByIDs**
- **:bug: mustMakeUserがadminを作れるにする**
- **:sparkles: repositoryのGetAdmins**
- **:sparkles: repositoryのAddAdmins**
- **:sparkles: repositoryのDeleteAdmins**
- **:adhesive_bandage: usecaseにAdminUseCaseを追加**
- **:factory: モックの生成**
- **:sparkles: handlerのPutAdmins**
- **:sparkles: /adminsエンドポイントの追加**
