### PR TITLE
CODEOWNERSファイルの導入

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @traPtitech/piscon-portal

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       time: "00:00"
       day: saturday
       timezone: Asia/Tokyo
-    reviewers:
-      - traPtitech/piscon-portal
 
   - directory: /
     open-pull-requests-limit: 5
@@ -21,5 +19,3 @@ updates:
       time: "00:00"
       day: saturday
       timezone: Asia/Tokyo
-    reviewers:
-      - traPtitech/piscon-portal


### PR DESCRIPTION
dependabot の設定で、 reviewers がそのうち使えなくなって、代わりにCODEOWNERSを使うことをおすすめされた

https://github.com/traPtitech/piscon-portal-v2/pull/115#issuecomment-2904806077

- **:wrench: CODEOWNERSファイル追加**
- **:fire: dependabot.ymlからreviewersを削除**
