### PR TITLE
PATCH /docsの実装

### DIFF
--- a/server/handler/document.go
+++ b/server/handler/document.go
@@ -34,3 +34,21 @@ func (h *Handler) GetDocument(c echo.Context) error {
 	}
 	return c.JSON(http.StatusOK, body)
 }
+
+func (h *Handler) PatchDocument(c echo.Context) error {
+	var body openapi.PatchDocsReq
+	if err := c.Bind(&body); err != nil {
+		return badRequestResponse(c, err.Error())
+	}
+
+	doc, err := h.useCase.CreateDocument(c.Request().Context(), string(body.Body))
+	if err != nil {
+		return internalServerErrorResponse(c, err)
+	}
+
+	res := openapi.PatchDocsOK{
+		Body: openapi.NewOptMarkdownDocument(openapi.MarkdownDocument(doc.Body)),
+	}
+
+	return c.JSON(http.StatusOK, res)
+}

--- a/server/handler/document_test.go
+++ b/server/handler/document_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/piscon-portal-v2/server/domain"
 	"github.com/traPtitech/piscon-portal-v2/server/handler/openapi"
 	repomock "github.com/traPtitech/piscon-portal-v2/server/repository/mock"
@@ -91,6 +93,80 @@ func TestGetDocument(t *testing.T) {
 
 			b := rec.Body.Bytes()
 			err := json.Unmarshal(b, &body)
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.res.Body, body.Body)
+		})
+	}
+}
+
+func TestPatchDocument(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	testCases := map[string]struct {
+		reqBody             openapi.PatchDocsReq
+		doc                 domain.Document
+		CreateDocumentError error
+		code                int
+		res                 openapi.PatchDocsOK
+	}{
+		"正しくドキュメントを作成できる": {
+			reqBody: openapi.PatchDocsReq{
+				Body: openapi.MarkdownDocument("test document body"),
+			},
+			doc: domain.Document{
+				ID:        uuid.New(),
+				Body:      "test document body",
+				CreatedAt: time.Now(),
+			},
+			res: openapi.PatchDocsOK{
+				Body: openapi.NewOptMarkdownDocument(openapi.MarkdownDocument("test document body")),
+			},
+			code: http.StatusOK,
+		},
+		"CreateDocumentでエラーが発生する": {
+			reqBody: openapi.PatchDocsReq{
+				Body: openapi.MarkdownDocument("test document body"),
+			},
+			CreateDocumentError: assert.AnError,
+			code:                http.StatusInternalServerError,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			usecaseMock := usecasemock.NewMockUseCase(ctrl)
+
+			usecaseMock.EXPECT().CreateDocument(gomock.Any(), string(testCase.reqBody.Body)).
+				Return(testCase.doc, testCase.CreateDocumentError)
+
+			h := NewHandler(usecaseMock, nil, nil)
+
+			var reqBody bytes.Buffer
+			err := json.NewEncoder(&reqBody).Encode(testCase.reqBody)
+			require.NoError(t, err)
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPatch, "/docs", &reqBody)
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err = h.PatchDocument(c)
+
+			assert.Equal(t, testCase.code, rec.Code)
+
+			if testCase.code != http.StatusOK {
+				return
+			}
+
+			assert.NoError(t, err)
+			var body openapi.PatchDocsOK
+			b := rec.Body.Bytes()
+			err = json.Unmarshal(b, &body)
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.res.Body, body.Body)
 		})

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -84,6 +84,7 @@ func (h *Handler) SetupRoutes(e *echo.Echo) {
 
 	docs := api.Group("/docs", h.AuthMiddleware())
 	docs.GET("", h.GetDocument)
+	docs.PATCH("", h.PatchDocument, h.AdminAuthMiddleware())
 
 	admins := api.Group("/admins", h.AdminAuthMiddleware())
 	admins.PUT("", h.PutAdmins)

--- a/server/repository/db/db_test.go
+++ b/server/repository/db/db_test.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"math/rand/v2"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -52,7 +53,8 @@ func setupRepository(t *testing.T) (*dbrepo.Repository, bob.Executor) {
 	if err := createDatabase(dbName); err != nil {
 		t.Fatal(err)
 	}
-	connection := mysqlContainer.MustConnectionString(ctx, "parseTime=true", "loc=Local")
+
+	connection := mysqlContainer.MustConnectionString(ctx, "parseTime=true", url.QueryEscape("loc=Local"))
 	db, err := sql.Open("mysql", connection)
 	if err != nil {
 		t.Fatal(err)

--- a/server/repository/db/document.go
+++ b/server/repository/db/document.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/stephenafamo/bob/dialect/mysql/sm"
 	"github.com/traPtitech/piscon-portal-v2/server/domain"
 	"github.com/traPtitech/piscon-portal-v2/server/repository"
@@ -27,6 +29,22 @@ func (r *Repository) GetDocument(ctx context.Context) (domain.Document, error) {
 		return domain.Document{}, err
 	}
 	return domainDoc, nil
+}
+
+func (r *Repository) CreateDocument(ctx context.Context, id uuid.UUID, body string) (domain.Document, error) {
+	_, err := models.Documents.Insert(&models.DocumentSetter{
+		ID:   lo.ToPtr(id.String()),
+		Body: lo.ToPtr(body),
+	}).Exec(ctx, r.executor(ctx))
+	if err != nil {
+		return domain.Document{}, fmt.Errorf("insert document: %w", err)
+	}
+
+	return domain.Document{
+		ID:        id,
+		Body:      body,
+		CreatedAt: time.Now(),
+	}, nil
 }
 
 func toDomainDocument(doc *models.Document) (domain.Document, error) {

--- a/server/repository/db/document_test.go
+++ b/server/repository/db/document_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stephenafamo/bob/dialect/mysql"
 	"github.com/stephenafamo/bob/dialect/mysql/dm"
+	"github.com/stephenafamo/bob/dialect/mysql/sm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/traPtitech/piscon-portal-v2/server/domain"
@@ -71,4 +72,61 @@ func TestGetDocument(t *testing.T) {
 		})
 	}
 
+}
+
+func TestCreateDocument(t *testing.T) {
+	t.Parallel()
+
+	repo, db := setupRepository(t)
+
+	doc := domain.Document{
+		ID:        uuid.New(),
+		Body:      "test document body",
+		CreatedAt: time.Now(),
+	}
+
+	testCases := map[string]struct {
+		doc domain.Document
+		err error
+	}{
+		"正しく作成できる": {
+			doc: doc,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			newDoc, err := repo.CreateDocument(t.Context(), testCase.doc.ID, testCase.doc.Body)
+
+			if testCase.err != nil {
+				assert.ErrorIs(t, err, testCase.err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if err != nil {
+				return
+			}
+
+			assert.Equal(t, newDoc.ID, testCase.doc.ID)
+			assert.Equal(t, newDoc.Body, testCase.doc.Body)
+			assert.WithinDuration(t, newDoc.CreatedAt, time.Now(), time.Second)
+
+			resultDoc, err := models.Documents.Query(
+				sm.Where(models.DocumentColumns.ID.EQ(mysql.Arg(newDoc.ID.String()))),
+				sm.Limit(1),
+			).One(t.Context(), db)
+			assert.NoError(t, err)
+			assert.Equal(t, newDoc.ID.String(), resultDoc.ID)
+			assert.Equal(t, newDoc.Body, resultDoc.Body)
+			assert.WithinDuration(t, newDoc.CreatedAt, resultDoc.CreatedAt, time.Second)
+
+			t.Cleanup(func() {
+				_, err := models.Documents.Delete(
+					dm.Where(models.DocumentColumns.ID.EQ(mysql.Arg(newDoc.ID.String()))),
+				).Exec(context.Background(), db)
+				require.NoError(t, err)
+			})
+		})
+	}
 }

--- a/server/repository/document.go
+++ b/server/repository/document.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/traPtitech/piscon-portal-v2/server/domain"
 )
 
@@ -10,4 +11,6 @@ type DocumentRepository interface {
 	// GetDocument retrieves the document.
 	// If the document does not exist, it returns ErrNotFound.
 	GetDocument(ctx context.Context) (domain.Document, error)
+	// CreateDocument creates a new document with the given ID and body.
+	CreateDocument(ctx context.Context, id uuid.UUID, body string) (domain.Document, error)
 }

--- a/server/repository/mock/repository.go
+++ b/server/repository/mock/repository.go
@@ -119,6 +119,45 @@ func (c *MockRepositoryCreateBenchmarkCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
+// CreateDocument mocks base method.
+func (m *MockRepository) CreateDocument(ctx context.Context, id uuid.UUID, body string) (domain.Document, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateDocument", ctx, id, body)
+	ret0, _ := ret[0].(domain.Document)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateDocument indicates an expected call of CreateDocument.
+func (mr *MockRepositoryMockRecorder) CreateDocument(ctx, id, body any) *MockRepositoryCreateDocumentCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDocument", reflect.TypeOf((*MockRepository)(nil).CreateDocument), ctx, id, body)
+	return &MockRepositoryCreateDocumentCall{Call: call}
+}
+
+// MockRepositoryCreateDocumentCall wrap *gomock.Call
+type MockRepositoryCreateDocumentCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockRepositoryCreateDocumentCall) Return(arg0 domain.Document, arg1 error) *MockRepositoryCreateDocumentCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockRepositoryCreateDocumentCall) Do(f func(context.Context, uuid.UUID, string) (domain.Document, error)) *MockRepositoryCreateDocumentCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockRepositoryCreateDocumentCall) DoAndReturn(f func(context.Context, uuid.UUID, string) (domain.Document, error)) *MockRepositoryCreateDocumentCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateInstance mocks base method.
 func (m *MockRepository) CreateInstance(ctx context.Context, instance domain.Instance) error {
 	m.ctrl.T.Helper()

--- a/server/usecase/document.go
+++ b/server/usecase/document.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/traPtitech/piscon-portal-v2/server/domain"
 	"github.com/traPtitech/piscon-portal-v2/server/repository"
 )
@@ -13,6 +14,8 @@ type DocumentUseCase interface {
 	// GetDocument retrieves the document.
 	// If the document does not exist, it returns ErrNotFound.
 	GetDocument(ctx context.Context) (domain.Document, error)
+	// CreateDocument creates a new document with the given body.
+	CreateDocument(ctx context.Context, body string) (domain.Document, error)
 }
 
 type docUseCaseImpl struct {
@@ -30,6 +33,16 @@ func (u *docUseCaseImpl) GetDocument(ctx context.Context) (domain.Document, erro
 	}
 	if err != nil {
 		return domain.Document{}, fmt.Errorf("get document: %w", err)
+	}
+
+	return doc, nil
+}
+
+func (u *docUseCaseImpl) CreateDocument(ctx context.Context, body string) (domain.Document, error) {
+	docID := uuid.New()
+	doc, err := u.repo.CreateDocument(ctx, docID, body)
+	if err != nil {
+		return domain.Document{}, fmt.Errorf("create document: %w", err)
 	}
 
 	return doc, nil

--- a/server/usecase/document_test.go
+++ b/server/usecase/document_test.go
@@ -78,3 +78,54 @@ func TestGetDocument(t *testing.T) {
 	}
 
 }
+
+func TestCreateDocument(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	testCases := map[string]struct {
+		body           string
+		doc            domain.Document
+		CreateDocError error
+		err            error
+	}{
+		"正しくドキュメントを作成できる": {
+			body: "test document body",
+			doc: domain.Document{
+				ID:        uuid.New(),
+				Body:      "test document body",
+				CreatedAt: time.Now(),
+			},
+		},
+		"CreateDocumentでエラーが発生する": {
+			body:           "test document body",
+			CreateDocError: assert.AnError,
+			err:            assert.AnError,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			mockRepo := mock.NewMockRepository(ctrl)
+			mockRepo.EXPECT().CreateDocument(gomock.Any(), gomock.Any(), testCase.body).
+				Return(testCase.doc, testCase.CreateDocError)
+
+			docUseCase := usecase.NewDocumentUseCase(mockRepo)
+
+			doc, err := docUseCase.CreateDocument(t.Context(), testCase.body)
+
+			if testCase.err != nil {
+				assert.ErrorIs(t, err, testCase.err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.doc.ID, doc.ID)
+			assert.Equal(t, testCase.doc.Body, doc.Body)
+			assert.WithinDuration(t, testCase.doc.CreatedAt, doc.CreatedAt, time.Second)
+		})
+	}
+}

--- a/server/usecase/mock/usecase.go
+++ b/server/usecase/mock/usecase.go
@@ -83,6 +83,45 @@ func (c *MockUseCaseCreateBenchmarkCall) DoAndReturn(f func(context.Context, uui
 	return c
 }
 
+// CreateDocument mocks base method.
+func (m *MockUseCase) CreateDocument(ctx context.Context, body string) (domain.Document, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateDocument", ctx, body)
+	ret0, _ := ret[0].(domain.Document)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateDocument indicates an expected call of CreateDocument.
+func (mr *MockUseCaseMockRecorder) CreateDocument(ctx, body any) *MockUseCaseCreateDocumentCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDocument", reflect.TypeOf((*MockUseCase)(nil).CreateDocument), ctx, body)
+	return &MockUseCaseCreateDocumentCall{Call: call}
+}
+
+// MockUseCaseCreateDocumentCall wrap *gomock.Call
+type MockUseCaseCreateDocumentCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockUseCaseCreateDocumentCall) Return(arg0 domain.Document, arg1 error) *MockUseCaseCreateDocumentCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockUseCaseCreateDocumentCall) Do(f func(context.Context, string) (domain.Document, error)) *MockUseCaseCreateDocumentCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockUseCaseCreateDocumentCall) DoAndReturn(f func(context.Context, string) (domain.Document, error)) *MockUseCaseCreateDocumentCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateInstance mocks base method.
 func (m *MockUseCase) CreateInstance(ctx context.Context, teamID uuid.UUID) (domain.Instance, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- **:sparkles: usecaseのCreateDocumentを実装**
- **:factory: モック生成**
- **:white_check_mark: usecaseのCreateDocumentのテスト**
- **:sparkles: repositoryのCreateDocumentを実装**
- **:white_check_mark: CreateDocumentのテスト**
- **:sparkles: handlerのPatchDocumentを実装**
- **:white_check_mark: handlerのPatchDocumentのテスト**
- **:sparkles: ハンドラーの登録**
