### PR TITLE
ローカルでrunnerを動かせるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ CLIENT_ID=my-client-id
 CLIENT_SECRET=my-client-secret
 ```
 traQで作成するClientは リダイレクトURL に `http://localhost:8080/api/oauth2/callback`、スコープに `openid`, `profile` を指定します。
-`task run-server` で portal server が 8080番 ポートで起動します。
+`task up` で portal server が 8080番 ポートで起動します。`task dev` でホットリロード付きで起動します。
 
 Go 1.24で入った experimental な機能である `testing/synctest` を [runner/runner_test.go](runner/runner_test.go) で使っています。2025/2/26時点でこれを動かすためには、環境変数で `GOEXPERIMENT=synctest` を設定する必要があります。VSCode であれば、 `.vscode/settings.json` に
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ```
 DB_USER=root
 DB_PASSWORD=password
-DB_HOST=localhost
+DB_HOST=db
 DB_PORT=3306
 DB_NAME=portal
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,14 +4,6 @@ env:
   GOEXPERIMENT: "synctest"
 
 tasks:
-  run-server:
-    dotenv:
-      - .env
-    deps:
-      - up-db
-    cmds:
-      - go run cmd/server/main.go
-
   test:
     cmds:
       - go test -cover -race ./...

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,6 +53,21 @@ tasks:
       - task: runner:gen
       - task: proto:gen
 
+  up:
+    cmds:
+      - docker compose up --detach --build
+    desc: アプリ全体を起動する
+
+  down:
+    cmds:
+      - docker compose down
+    desc: アプリ全体を停止する
+
+  logs:
+    cmds:
+      - docker compose logs --follow {{.CLI_ARGS}}
+    desc: コンテナのログを表示する。 task logs -- {コンテナ名} で特定のコンテナのログを表示できる
+
   up-db:
     cmds:
       - docker compose up -d --wait db

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,6 +58,11 @@ tasks:
       - docker compose up --detach --build
     desc: アプリ全体を起動する
 
+  dev:
+    cmds:
+      - docker compose watch
+    desc: ホットリロード付きでアプリ全体を起動する
+
   down:
     cmds:
       - docker compose down

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -14,6 +14,7 @@ import (
 	privateisu "github.com/traPtitech/piscon-portal-v2/runner/benchmarker/impl/private_isu"
 	portalGrpc "github.com/traPtitech/piscon-portal-v2/runner/portal/grpc"
 	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -60,7 +61,8 @@ func main() {
 		log.Fatalf("validation error: %v", err)
 	}
 
-	conn, err := grpc.NewClient(*target)
+	conn, err := grpc.NewClient(*target,
+		grpc.WithTransportCredentials(insecure.NewCredentials())) //TODO: TLS を有効にする
 	if err != nil {
 		log.Fatalf("failed to connect: %v", err)
 	}
@@ -77,6 +79,8 @@ func main() {
 	}
 
 	r := runner.Prepare(p, bench(benchConfig))
+
+	log.Printf("runner started: target=%s, problem=%s\n", *target, *problem)
 
 	for {
 		if err := r.Run(); err != nil {

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,3 +13,34 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+
+  portal:
+    build:
+      context: .
+      dockerfile: portal.Dockerfile
+    ports:
+      - 8080:8080
+    depends_on:
+      db:
+        condition: service_healthy
+    expose:
+      - 50051
+    env_file:
+      - .env
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "http://localhost:8080/api/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+
+  runner:
+    build:
+      context: .
+      dockerfile: runner.Dockerfile
+    entrypoint:
+      ["/bin/runner", "--target", "portal:50051", "--problem", "example"]
+    depends_on:
+      portal:
+        condition: service_healthy
+    volumes:
+      - ./runner/benchmarker/impl/example.sh:/bin/example.sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,14 @@ services:
       interval: 10s
       timeout: 10s
       retries: 5
+    develop:
+      watch:
+        - path: ./server
+          action: "rebuild"
+        - path: ./cmd/server
+          action: "rebuild"
+        - path: ./gen
+          action: "rebuild"
 
   runner:
     build:
@@ -44,3 +52,11 @@ services:
         condition: service_healthy
     volumes:
       - ./runner/benchmarker/impl/example.sh:/bin/example.sh
+    develop:
+      watch:
+        - path: ./runner
+          action: "rebuild"
+        - path: ./cmd/runner
+          action: "rebuild"
+        - path: ./gen
+          action: "rebuild"

--- a/portal.Dockerfile
+++ b/portal.Dockerfile
@@ -1,0 +1,77 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
+
+################################################################################
+# Create a stage for building the application.
+ARG GO_VERSION=1.24.4
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS build
+WORKDIR /src
+
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage bind mounts to go.sum and go.mod to avoid having to copy them into
+# the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
+
+# This is the architecture you're building for, which is passed in by the builder.
+# Placing it here allows the previous steps to be cached across architectures.
+ARG TARGETARCH
+
+# Build the application.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage a bind mount to the current directory to avoid having to copy the
+# source code into the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,target=. \
+  CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /bin/server ./cmd/server
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the alpine image as the foundation for running the app.
+# By specifying the "latest" tag, it will also use whatever happens to be the
+# most recent version of that image when you build your Dockerfile. If
+# reproducibility is important, consider using a versioned tag
+# (e.g., alpine:3.17.2) or SHA (e.g., alpine@sha256:c41ab5c992deb4fe7e5da09f67a8804a46bd0592bfdf0b1847dde0e0889d2bff).
+FROM alpine:latest AS final
+
+# Install any runtime dependencies that are needed to run your application.
+# Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.
+RUN --mount=type=cache,target=/var/cache/apk \
+  apk --update add \
+  ca-certificates \
+  tzdata \
+  && \
+  update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "/nonexistent" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid "${UID}" \
+  appuser
+USER appuser
+
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/server /bin/
+
+EXPOSE 8080 50051
+
+# What the container should run when it is started.
+ENTRYPOINT [ "/bin/server" ]

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -1,0 +1,75 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
+
+################################################################################
+# Create a stage for building the application.
+ARG GO_VERSION=1.24.4
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS build
+WORKDIR /src
+
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage bind mounts to go.sum and go.mod to avoid having to copy them into
+# the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,source=go.sum,target=go.sum \
+  --mount=type=bind,source=go.mod,target=go.mod \
+  go mod download -x
+
+# This is the architecture you're building for, which is passed in by the builder.
+# Placing it here allows the previous steps to be cached across architectures.
+ARG TARGETARCH
+
+# Build the application.
+# Leverage a cache mount to /go/pkg/mod/ to speed up subsequent builds.
+# Leverage a bind mount to the current directory to avoid having to copy the
+# source code into the container.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+  --mount=type=bind,target=. \
+  CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /bin/runner ./cmd/runner
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the alpine image as the foundation for running the app.
+# By specifying the "latest" tag, it will also use whatever happens to be the
+# most recent version of that image when you build your Dockerfile. If
+# reproducibility is important, consider using a versioned tag
+# (e.g., alpine:3.17.2) or SHA (e.g., alpine@sha256:c41ab5c992deb4fe7e5da09f67a8804a46bd0592bfdf0b1847dde0e0889d2bff).
+FROM alpine:latest AS final
+
+# Install any runtime dependencies that are needed to run your application.
+# Leverage a cache mount to /var/cache/apk/ to speed up subsequent builds.
+RUN --mount=type=cache,target=/var/cache/apk \
+  apk --update add \
+  ca-certificates \
+  tzdata \
+  && \
+  update-ca-certificates
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+  --disabled-password \
+  --gecos "" \
+  --home "/nonexistent" \
+  --shell "/sbin/nologin" \
+  --no-create-home \
+  --uid "${UID}" \
+  appuser
+USER appuser
+
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/runner /bin/
+
+# What the container should run when it is started.
+ENTRYPOINT [ "/bin/runner" ]

--- a/runner/benchmarker/impl/example.go
+++ b/runner/benchmarker/impl/example.go
@@ -28,7 +28,7 @@ func NewExample() *Example {
 var _ benchmarker.Benchmarker = (*Example)(nil)
 
 func (b *Example) Start(ctx context.Context, job *domain.Job) (benchmarker.Outputs, time.Time, error) {
-	cmd := exec.CommandContext(ctx, "./example.sh", job.GetTargetURL())
+	cmd := exec.CommandContext(ctx, "/bin/example.sh", job.GetTargetURL())
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 
 	"github.com/labstack/echo/v4"
@@ -55,6 +56,10 @@ func New(useCase usecase.UseCase, repo repository.Repository, config Config) (*H
 func (h *Handler) SetupRoutes(e *echo.Echo) {
 	api := e.Group("/api")
 	h.sessionManager.Init(api)
+
+	api.GET("/health", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
 
 	api.GET("/oauth2/code", h.GetOauth2Code)
 	api.GET("/oauth2/callback", h.Oauth2Callback)


### PR DESCRIPTION
docker composeでportalとrunnerが動くようにした。

- **:wrench: portalとrunnerのDockerfileを追加**
- **:adhesive_bandage: healthcheckのエンドポイントを追加**
- **:adhesive_bandage: exampleのベンチマーカーのパス修正**
- **:adhesive_bandage: gRPCクライアントのcredentialsの設定**
- **:wrench: compose.yamlにportalとrunnerのサービスを追加**
- **:wrench: Taskfileにアプリの起動、停止、ログを見るためのコマンドを追加**
- **:memo: ドキュメントの環境変数設定を修正**
