### PR TITLE
runnerの設定をファイルから読むようにする

### DIFF
--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -6,53 +6,35 @@ import (
 
 	portalv1 "github.com/traPtitech/piscon-portal-v2/gen/portal/v1"
 	"github.com/traPtitech/piscon-portal-v2/runner"
-	"github.com/traPtitech/piscon-portal-v2/runner/benchmarker"
-	benchImpl "github.com/traPtitech/piscon-portal-v2/runner/benchmarker/impl"
-	privateisu "github.com/traPtitech/piscon-portal-v2/runner/benchmarker/impl/private_isu"
 	"github.com/traPtitech/piscon-portal-v2/runner/config"
 	portalGrpc "github.com/traPtitech/piscon-portal-v2/runner/portal/grpc"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const (
-	problemExample    string = "example"
-	problemPrivateIsu string = "private_isu"
-)
-
-var (
-	problemBenchmarks = map[string]func(config map[string]any) benchmarker.Benchmarker{
-		problemExample: func(_ map[string]any) benchmarker.Benchmarker {
-			return benchImpl.NewExample()
-		},
-		problemPrivateIsu: func(_ map[string]any) benchmarker.Benchmarker {
-			return privateisu.New()
-		},
-	}
-)
-
 func main() {
 	config, err := config.LoadFile()
 	if err != nil {
 		log.Fatalf("failed to load config: %v", err)
+		return
 	}
 
 	conn, err := grpc.NewClient(config.Portal.Address,
 		grpc.WithTransportCredentials(insecure.NewCredentials())) //TODO: TLS を有効にする
 	if err != nil {
 		log.Fatalf("failed to connect: %v", err)
+		return
 	}
 	defer conn.Close()
 
 	client := portalv1.NewBenchmarkServiceClient(conn)
 	p := portalGrpc.NewPortal(client, time.Second)
 
-	bench, ok := problemBenchmarks[config.Problem.Name]
-	if !ok {
-		log.Fatalf("problem %q is not found", config.Problem.Name)
+	r, err := runner.Prepare(p, config.Problem)
+	if err != nil {
+		log.Fatalf("failed to prepare runner: %v", err)
+		return
 	}
-
-	r := runner.Prepare(p, bench(config.Problem.Options))
 
 	log.Printf("runner started: portal=%s, problem=%s\n", config.Portal.Address, config.Problem.Name)
 

--- a/cmd/runner/main.go
+++ b/cmd/runner/main.go
@@ -1,17 +1,15 @@
 package main
 
 import (
-	"errors"
-	"fmt"
 	"log"
 	"time"
 
-	"github.com/spf13/pflag"
 	portalv1 "github.com/traPtitech/piscon-portal-v2/gen/portal/v1"
 	"github.com/traPtitech/piscon-portal-v2/runner"
 	"github.com/traPtitech/piscon-portal-v2/runner/benchmarker"
 	benchImpl "github.com/traPtitech/piscon-portal-v2/runner/benchmarker/impl"
 	privateisu "github.com/traPtitech/piscon-portal-v2/runner/benchmarker/impl/private_isu"
+	"github.com/traPtitech/piscon-portal-v2/runner/config"
 	portalGrpc "github.com/traPtitech/piscon-portal-v2/runner/portal/grpc"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -23,11 +21,6 @@ const (
 )
 
 var (
-	problems = []string{problemExample, problemPrivateIsu}
-	target   = pflag.StringP("target", "t", "", "portal server address (host:port)")
-	problem  = pflag.StringP("problem", "p", "", fmt.Sprintf("problem name: one of %v", problems))
-	help     = pflag.BoolP("help", "h", false, "show help (this message)")
-
 	problemBenchmarks = map[string]func(config map[string]any) benchmarker.Benchmarker{
 		problemExample: func(_ map[string]any) benchmarker.Benchmarker {
 			return benchImpl.NewExample()
@@ -38,30 +31,13 @@ var (
 	}
 )
 
-func validateFlags() error {
-	if target == nil || *target == "" {
-		return errors.New("target is required")
-	}
-	if problem == nil || *problem == "" {
-		return errors.New("problem is required")
-	}
-	return nil
-}
-
 func main() {
-	pflag.Parse()
-
-	if help != nil && *help {
-		pflag.Usage()
-		return
+	config, err := config.LoadFile()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
 	}
 
-	if err := validateFlags(); err != nil {
-		pflag.Usage()
-		log.Fatalf("validation error: %v", err)
-	}
-
-	conn, err := grpc.NewClient(*target,
+	conn, err := grpc.NewClient(config.Portal.Address,
 		grpc.WithTransportCredentials(insecure.NewCredentials())) //TODO: TLS を有効にする
 	if err != nil {
 		log.Fatalf("failed to connect: %v", err)
@@ -71,16 +47,14 @@ func main() {
 	client := portalv1.NewBenchmarkServiceClient(conn)
 	p := portalGrpc.NewPortal(client, time.Second)
 
-	benchConfig := map[string]any{}
-
-	bench, ok := problemBenchmarks[*problem]
+	bench, ok := problemBenchmarks[config.Problem.Name]
 	if !ok {
-		log.Fatalf("problem %q is not found", *problem)
+		log.Fatalf("problem %q is not found", config.Problem.Name)
 	}
 
-	r := runner.Prepare(p, bench(benchConfig))
+	r := runner.Prepare(p, bench(config.Problem.Options))
 
-	log.Printf("runner started: target=%s, problem=%s\n", *target, *problem)
+	log.Printf("runner started: portal=%s, problem=%s\n", config.Portal.Address, config.Problem.Name)
 
 	for {
 		if err := r.Run(); err != nil {

--- a/compose.yaml
+++ b/compose.yaml
@@ -54,6 +54,7 @@ services:
         condition: service_healthy
     volumes:
       - ./runner/benchmarker/impl/example.sh:/bin/example.sh
+      - ./piscon_runner_example.yaml:/piscon_runner.yaml
     develop:
       watch:
         - path: ./runner

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/labstack/echo/v4 v4.13.4
 	github.com/ogen-go/ogen v1.14.0
 	github.com/samber/lo v1.51.0
-	github.com/spf13/pflag v1.0.7
+	github.com/spf13/viper v1.20.1
 	github.com/stephenafamo/bob v0.38.0
 	github.com/stephenafamo/scan v0.7.0
 	github.com/stretchr/testify v1.10.0
@@ -72,14 +72,14 @@ require (
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-faster/yaml v0.4.6 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/gorilla/context v1.1.2 // indirect
@@ -109,17 +109,23 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/qdm12/reprint v0.0.0-20200326205758-722754a53494 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.5 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	github.com/spf13/cast v1.7.0 // indirect
+	github.com/sourcegraph/conc v0.3.0 // indirect
+	github.com/spf13/afero v1.12.0 // indirect
+	github.com/spf13/cast v1.7.1 // indirect
+	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/stephenafamo/sqlparser v0.0.0-20250521201114-5cfed001272d // indirect
+	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/testcontainers/testcontainers-go v0.38.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/friendsofgo/errors v0.9.2 h1:X6NYxef4efCBdwI7BgS820zFaN7Cphrmb+Pljdzjtgk=
 github.com/friendsofgo/errors v0.9.2/go.mod h1:yCvFW5AkDIL9qn7suHVLiI/gH228n7PC4Pn44IGoTOI=
-github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=
@@ -113,8 +113,8 @@ github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
-github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 h1:TQcrn6Wq+sKGkpyPvppOz99zsMBaUOKXq6HSv655U1c=
-github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
+github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v5 v5.2.3 h1:kkGXqQOBSDDWRhWNXTFpqGSCMyh/PLnqUvMGJPDJDs0=
@@ -206,6 +206,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
+github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -218,6 +220,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
+github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
 github.com/samber/lo v1.51.0 h1:kysRYLbHy/MB7kQZf5DSN50JHmMsNEdeY24VzJFu7wI=
 github.com/samber/lo v1.51.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
@@ -228,10 +232,16 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
-github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
+github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
+github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
+github.com/spf13/afero v1.12.0/go.mod h1:ZTlWwG4/ahT8W7T0WQ5uYmjI9duaLQGy3Q2OAl4sk/4=
+github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
+github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
 github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
+github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
 github.com/stephenafamo/bob v0.38.0 h1:G2+VfEiP4CdpXNmq27J77UuEnw/pcieDogKQw9sRUJs=
 github.com/stephenafamo/bob v0.38.0/go.mod h1:8MbdjERiyoFRDX1HK9bcOupCayWUG0A7wrKf3wynU/k=
 github.com/stephenafamo/fakedb v0.0.0-20221230081958-0b86f816ed97 h1:XItoZNmhOih06TC02jK7l3wlpZ0XT/sPQYutDcGOQjg=
@@ -247,6 +257,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
+github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/testcontainers/testcontainers-go v0.38.0 h1:d7uEapLcv2P8AvH8ahLqDMMxda2W9gQN1nRbHS28HBw=
 github.com/testcontainers/testcontainers-go v0.38.0/go.mod h1:C52c9MoHpWO+C4aqmgSU+hxlR5jlEayWtgYrb8Pzz1w=
 github.com/testcontainers/testcontainers-go/modules/mysql v0.38.0 h1:msUPAl0LVBalG3m2KhmbFHeRrxCw36xmQFCEhzqsvqo=
@@ -330,7 +342,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
@@ -355,6 +366,7 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
+google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 h1:ToEetK57OidYuqD4Q5w+vfEnPvPpuTwedCNVohYJfNk=
 google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a h1:SGktgSolFCo75dnHJF2yMvnns6jCmHFJ0vE4Vn2JKvQ=
 google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a/go.mod h1:a77HrdMjoeKbnd2jmgcWdaS++ZLZAEq3orIOAEIKiVw=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a h1:v2PbRU4K3llS09c7zodFpNePeamkAwG3mPrAery9VeE=

--- a/piscon_runner_example.yaml
+++ b/piscon_runner_example.yaml
@@ -1,0 +1,4 @@
+portal:
+  address: portal:50051
+problem:
+  name: example

--- a/runner/config/config.go
+++ b/runner/config/config.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+func LoadFile() (Config, error) {
+	viper.SetConfigName("piscon_runner")
+	viper.AddConfigPath(".")
+
+	if err := viper.ReadInConfig(); err != nil {
+		return Config{}, fmt.Errorf("read config: %w", err)
+	}
+
+	var cfg Config
+	if err := viper.Unmarshal(&cfg); err != nil {
+		return Config{}, fmt.Errorf("unmarshal config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+type Portal struct {
+	Address string `mapstructure:"address"`
+}
+
+type Problem struct {
+	Name    string         `mapstructure:"name"`
+	Options map[string]any `mapstructure:"options"`
+}
+
+type Config struct {
+	Portal  Portal  `mapstructure:"portal"`
+	Problem Problem `mapstructure:"problem"`
+}
+
+func (c Config) Validate() error {
+	if c.Portal.Address == "" {
+		return fmt.Errorf("portal address is required")
+	}
+	if c.Problem.Name == "" {
+		return fmt.Errorf("problem name is required")
+	}
+
+	return nil
+}


### PR DESCRIPTION
runnerをデプロイするときや、問題ごとに固有の設定を使いたいときに、引数で取るよりもファイルがある方がやりやすいため。

- **:sparkles: viperでファイルから設定を読むようにする**
- **:recycle: runnerパッケージ側で問題の切り替えをする**
- **:wrench: ローカル動作の設定を修正**
