### PR TITLE
:bug: OpenAPIのOneOfにReadyingBenchmarkを追加

### DIFF
--- a/server/handler/benchmark.go
+++ b/server/handler/benchmark.go
@@ -252,6 +252,7 @@ func toOpenAPIBenchmark(benchmark domain.Benchmark, log domain.BenchmarkLog) (*o
 			Type:              openapi.BenchmarkSumType(listItem.Type),
 			WaitingBenchmark:  listItem.WaitingBenchmark,
 			RunningBenchmark:  listItem.RunningBenchmark,
+			ReadyingBenchmark: listItem.ReadyingBenchmark,
 			FinishedBenchmark: listItem.FinishedBenchmark,
 		},
 	}, nil
@@ -281,6 +282,7 @@ func toOpenAPIBenchmarkAdminResult(benchmark domain.Benchmark, log domain.Benchm
 		OneOf: openapi.BenchmarkAdminResultSum{
 			Type:              openapi.BenchmarkAdminResultSumType(listItem.Type),
 			WaitingBenchmark:  listItem.WaitingBenchmark,
+			ReadyingBenchmark: listItem.ReadyingBenchmark,
 			RunningBenchmark:  listItem.RunningBenchmark,
 			FinishedBenchmark: listItem.FinishedBenchmark,
 		},


### PR DESCRIPTION
OpenAPIのBenchmarkのOneOfを取っているところで、Readyingを追加し忘れていた
