### PR TITLE
ベンチマークの初期状態が正しく送信されないのを修正

### DIFF
--- a/runner/benchmarker/impl/private_isu/private_isu.go
+++ b/runner/benchmarker/impl/private_isu/private_isu.go
@@ -108,6 +108,11 @@ func (b *PrivateIsu) Wait(_ context.Context) (domain.Result, time.Time, error) {
 func (b *PrivateIsu) CalculateScore(_ context.Context, allStdout, allStderr string) (int, error) {
 	b.stdout, b.stderr = allStdout, allStderr
 
+	if len(b.stdout) == 0 {
+		// 標準出力が空のときはまだ実行中なので、スコア0を返す
+		return 0, nil
+	}
+
 	var stdout stdOut
 	err := json.Unmarshal([]byte(b.stdout), &stdout)
 	if err != nil {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -130,6 +130,12 @@ func (r *Runner) streamJobProgress(
 	}
 	defer streamClient.Close()
 
+	// 初期状態を送信して、ポータルに開始を通知する。
+	initialProgress := domain.NewProgress(job.GetID(), "", "", 0, startedAt)
+	if err := streamClient.SendProgress(ctx, initialProgress); err != nil {
+		return fmt.Errorf("send initial progress: %w", err)
+	}
+
 	calcAndSendProgress := func() error {
 		stdout := stdoutBdr.String()
 		stderr := stderrBdr.String()


### PR DESCRIPTION
空文字列をJSONでパースしようとしてエラーを起こしていた。
progressを一度も送ってない状態でfinishを送ってしまうとstartedAtがnilのままになってしまってnil pointer dereferenceを起こしていた。

- **:bug: private_isuのベンチマークで、標準出力が空のときに0を返すようにする**
- **:bug: ベンチマーク開始前にprogressの初期状態を送信する**
