### PR TITLE
exampleのベンチマーカーを修正

### DIFF
--- a/runner/benchmarker/impl/example.go
+++ b/runner/benchmarker/impl/example.go
@@ -82,5 +82,5 @@ func (b *Example) CalculateScore(_ context.Context, allStdout, allStderr string)
 		}
 	}
 
-	return 0, fmt.Errorf("score not found")
+	return 0, nil
 }

--- a/runner/benchmarker/impl/example.sh
+++ b/runner/benchmarker/impl/example.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -z "$1" ]; then
   echo "Usage: $0 <target URL>"
@@ -7,10 +7,12 @@ fi
 
 TARGET_URL=$1
 
-for i in {1..20}; do 
+i=1
+while [ $i -le 20 ]; do
   echo "Score: $(($i * 100))"
   if [ $(($i % 5)) -eq 0 ]; then
     echo "Error: Some error" >&2
   fi
   sleep 1
+  i=$((i + 1))
 done


### PR DESCRIPTION
コンテナにbashが無かったため、shにする

- **:bug: ログが無いときにエラーになるのを修正**
- **:bug: exampleのベンチマーカーをbashからshにする**
