### PR TITLE
portal のビルドの go バージョン指定修正

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -35,6 +35,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read Go version
+        id: go-version
+        run: |
+          go_version="$(awk '$1 == "go" { print $2; exit }' go.mod)"
+          echo "version=${go_version}" >> "${GITHUB_OUTPUT}"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -53,5 +59,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: >
+            ${{ matrix.image.name == 'portal'
+              && format('GO_VERSION={0}', steps.go-version.outputs.version)
+              || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/portal.Dockerfile
+++ b/portal.Dockerfile
@@ -8,7 +8,7 @@
 
 ################################################################################
 # Create a stage for building the application.
-ARG GO_VERSION=1.24.4
+ARG GO_VERSION=1.25.0
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS build
 WORKDIR /src
 


### PR DESCRIPTION
go.mod で指定されているバージョンを見て、Go のベースイメージを指定するようにする

- **:wrench: イメージのビルドで Go のバージョン指定**
- **:adhesive_bandage: フォールバックのGoバージョンを更新**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Go ランタイムバージョンを 1.25.0 に更新しました
  * ビルドプロセスの自動化を改善し、バージョン管理をより効率的にしました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/piscon-portal-v2/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->