### PR TITLE
CDKでPortalのAMI IDを環境変数から指定するようにする

### DIFF
--- a/provisioning/aws/README.md
+++ b/provisioning/aws/README.md
@@ -28,6 +28,10 @@ npm install
 # Runner インスタンスの AMI ID (必須)
 RUNNER_AMI_ID="ami-xxxxxxxxxxxxxxxxx"
 
+# Portal インスタンスの AMI ID (必須)
+# 2026/05/16 時点 Ubuntu Server 24.04 x86 を推奨
+PORTAL_AMI_ID="ami-xxxxxxxxxxxxxxxxx"
+
 # 作成する Runner インスタンスの数 (任意、デフォルト: 1)
 # RUNNER_COUNT=1
 

--- a/provisioning/aws/bin/aws.ts
+++ b/provisioning/aws/bin/aws.ts
@@ -12,11 +12,17 @@ if (!runnerAmiId) {
 	throw new Error("RUNNER_AMI_ID is not configured");
 }
 
+const portalAmiId = process.env.PORTAL_AMI_ID;
+if (!portalAmiId) {
+	throw new Error("PORTAL_AMI_ID is not configured");
+}
+
 const config = {
 	portal: {
 		instanceType: new ec2.InstanceType(
 			process.env.PORTAL_INSTANCE_TYPE || "t3a.small",
 		),
+		amiId: portalAmiId,
 	},
 	runner: {
 		count: parseInt(process.env.RUNNER_COUNT || "1"),

--- a/provisioning/aws/lib/aws-stack.ts
+++ b/provisioning/aws/lib/aws-stack.ts
@@ -6,6 +6,7 @@ import { Construct } from "constructs";
 
 interface PortalConfig {
 	readonly instanceType: ec2.InstanceType;
+	readonly amiId: string;
 }
 
 interface RunnerConfig {
@@ -23,7 +24,6 @@ interface PisconStackProps extends cdk.StackProps {
 export class AwsStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props: PisconStackProps) {
 		super(scope, id, props);
-
 		const keyPair = new ec2.KeyPair(this, "ImportedKey", {
 			publicKeyMaterial: fs.readFileSync(props.sshPublicKeyPath, "utf8"),
 			keyPairName: "piscon-key-from-local",
@@ -62,7 +62,7 @@ export class AwsStack extends cdk.Stack {
 			vpc,
 			instanceType: props.portal.instanceType,
 			machineImage: ec2.MachineImage.genericLinux({
-				"ap-northeast-1": "ami-0aec5ae807cea9ce0", // Ubuntu 24.04 x86_64
+				"ap-northeast-1": props.portal.amiId,
 			}),
 			securityGroup: portalSg,
 			vpcSubnets: {


### PR DESCRIPTION
AMI の ID は変わるっぽいので



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * Portal インスタンスの AMI ID 設定手順を追加。Ubuntu Server 24.04 (x86)を推奨環境として明記しました。

* **Chores**
  * Portal インスタンスの AMI ID を環境変数で指定できるよう変更。設定がない場合は初期化時にエラーで停止するようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/piscon-portal-v2/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->