### PR TITLE
ISUCON11予選でrunnerがpanicするのを修正

### DIFF
--- a/provisioning/ansible/roles/runner/templates/problems/isucon11-qualify.yaml.j2
+++ b/provisioning/ansible/roles/runner/templates/problems/isucon11-qualify.yaml.j2
@@ -5,3 +5,4 @@ problem:
   options:
     benchmarker-path: /home/isucon/bench/bench
     benchmarker-ip: "{{ ansible_default_ipv4.address }}"
+    benchmarker-dir: /home/isucon/bench

--- a/runner/benchmarker/impl/isucon11-qualify/README.md
+++ b/runner/benchmarker/impl/isucon11-qualify/README.md
@@ -10,5 +10,5 @@ problem:
   options:
     benchmarker-path: /home/isucon/bench/bench
     benchmarker-ip: 192.168.0.3 # ベンチマーカー自身のipアドレス
+    benchmarker-dir: /home/isucon/bench # ベンチマーカーを実行するときのディレクトリ
 ```
-

--- a/runner/benchmarker/impl/isucon11-qualify/benchmark.go
+++ b/runner/benchmarker/impl/isucon11-qualify/benchmark.go
@@ -46,8 +46,6 @@ func New(conf config.Problem) (*Isucon11Qualify, error) {
 	}
 
 	return &Isucon11Qualify{
-		errCh:    make(chan error, 1),
-		passedCh: make(chan bool, 1),
 		conf: problemConf{
 			execPath:      path,
 			benchmarkerIP: benchmarkerIP,
@@ -56,15 +54,20 @@ func New(conf config.Problem) (*Isucon11Qualify, error) {
 }
 
 func (b *Isucon11Qualify) Start(ctx context.Context, job *domain.Job) (benchmarker.Outputs, time.Time, error) {
+	errCh := make(chan error, 1)
+	passedCh := make(chan bool, 1)
+
 	jiaServiceURL := url.URL{
 		Scheme: "http",
-		Host:   net.JoinHostPort(b.conf.benchmarkerIP, "5000"),
+		Host:   net.JoinHostPort(b.conf.benchmarkerIP, "4999"),
 	}
 	b.cmd = exec.CommandContext(ctx, b.conf.execPath,
 		"--target", job.GetTargetIPAdress(),
 		// tlsを使わない場合は`--all-adresses`にtargetだけ指定すればok
 		"--all-addresses", job.GetTargetIPAdress(),
 		"--jia-service-url", jiaServiceURL.String())
+
+	b.cmd.Dir = "/home/isucon/bench"
 
 	reportReader, reportWriter, err := os.Pipe()
 	if err != nil {
@@ -87,7 +90,11 @@ func (b *Isucon11Qualify) Start(ctx context.Context, job *domain.Job) (benchmark
 	}
 	reportWriter.Close()
 
-	go b.watchReport(reportReader)
+	b.errCh = errCh
+	b.passedCh = passedCh
+	b.latestScore.Store(0)
+
+	go b.watchReport(reportReader, errCh, passedCh)
 
 	return benchmarker.Outputs{
 		Stdout: stdout,
@@ -116,19 +123,19 @@ func (b *Isucon11Qualify) CalculateScore(_ context.Context, _, _ string) (int, e
 	return int(b.latestScore.Load()), nil
 }
 
-func (b *Isucon11Qualify) watchReport(report io.ReadCloser) {
+func (b *Isucon11Qualify) watchReport(report io.ReadCloser, errCh chan<- error, passedCh chan<- bool) {
 	defer report.Close()
-	defer close(b.errCh)
-	defer close(b.passedCh)
+	defer close(errCh)
+	defer close(passedCh)
 	for {
 		result, err := readResult(report)
 		if err != nil {
-			b.errCh <- err
+			errCh <- err
 			return
 		}
 		b.latestScore.Store(result.Score)
 		if result.Finished {
-			b.passedCh <- result.Passed
+			passedCh <- result.Passed
 			return
 		}
 	}

--- a/runner/benchmarker/impl/isucon11-qualify/benchmark.go
+++ b/runner/benchmarker/impl/isucon11-qualify/benchmark.go
@@ -20,8 +20,9 @@ import (
 )
 
 type problemConf struct {
-	benchmarkerIP string
-	execPath      string
+	benchmarkerIP  string
+	execPath       string
+	benchmarkerDir string
 }
 
 type Isucon11Qualify struct {
@@ -44,11 +45,16 @@ func New(conf config.Problem) (*Isucon11Qualify, error) {
 	if !ok || benchmarkerIP == "" {
 		return nil, fmt.Errorf("invalid or missing 'benchmarker-ip' option in problem configuration")
 	}
+	benchmarkerDir, ok := conf.Options["benchmarker-dir"].(string)
+	if !ok || benchmarkerDir == "" {
+		return nil, fmt.Errorf("invalid or missing 'benchmarker-dir' option in problem configuration")
+	}
 
 	return &Isucon11Qualify{
 		conf: problemConf{
-			execPath:      path,
-			benchmarkerIP: benchmarkerIP,
+			execPath:       path,
+			benchmarkerIP:  benchmarkerIP,
+			benchmarkerDir: benchmarkerDir,
 		},
 	}, nil
 }
@@ -67,7 +73,7 @@ func (b *Isucon11Qualify) Start(ctx context.Context, job *domain.Job) (benchmark
 		"--all-addresses", job.GetTargetIPAdress(),
 		"--jia-service-url", jiaServiceURL.String())
 
-	b.cmd.Dir = "/home/isucon/bench"
+	b.cmd.Dir = b.conf.benchmarkerDir
 
 	reportReader, reportWriter, err := os.Pipe()
 	if err != nil {

--- a/runner/benchmarker/impl/isucon11-qualify/benchmark_test.go
+++ b/runner/benchmarker/impl/isucon11-qualify/benchmark_test.go
@@ -1,0 +1,40 @@
+package isucon11qualify
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traPtitech/piscon-portal-v2/runner/domain"
+)
+
+func TestStartWaitCanRunSequentially(t *testing.T) {
+	truePath, err := exec.LookPath("true")
+	require.NoError(t, err)
+
+	b := &Isucon11Qualify{
+		conf: problemConf{
+			execPath:      truePath,
+			benchmarkerIP: "127.0.0.1",
+		},
+	}
+	ctx := context.Background()
+	job := domain.NewJob("job-id", "192.0.2.1")
+
+	for range 2 {
+		out, _, err := b.Start(ctx, job)
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(out.Stdout)
+		require.NoError(t, err)
+		_, err = io.ReadAll(out.Stderr)
+		require.NoError(t, err)
+
+		result, _, err := b.Wait(ctx)
+		require.ErrorContains(t, err, "parse benchmark result")
+		assert.Equal(t, domain.ResultError, result)
+	}
+}

--- a/runner/benchmarker/impl/isucon11-qualify/benchmark_test.go
+++ b/runner/benchmarker/impl/isucon11-qualify/benchmark_test.go
@@ -17,8 +17,9 @@ func TestStartWaitCanRunSequentially(t *testing.T) {
 
 	b := &Isucon11Qualify{
 		conf: problemConf{
-			execPath:      truePath,
-			benchmarkerIP: "127.0.0.1",
+			execPath:       truePath,
+			benchmarkerIP:  "127.0.0.1",
+			benchmarkerDir: "/tmp",
 		},
 	}
 	ctx := context.Background()


### PR DESCRIPTION
ベンチマーカー実行の2回目以降、close されてる channel に書き込んでしまっていたので panic していた。

- **:bug: ISUCON11で複数回ベンチマーカーを実行するとpanicする**
- **:white_check_mark: 複数回実行してもpanicしないテスト**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ベンチマークを連続して実行する際の安定性を向上しました。
  * ベンチマーク結果の読み取りと判定処理を改善しました。
  * 実行環境の接続先ポートと作業ディレクトリを更新しました。

* **テスト**
  * ベンチマークの開始と待機を連続して実行できることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->