### PR TITLE
問題サーバー用のセキュリティグループ

### DIFF
--- a/provisioning/ansible/README.md
+++ b/provisioning/ansible/README.md
@@ -65,7 +65,7 @@ local:
   aws:
     region: "{{ AWSのリージョン }}"
     subnet_id: "{{ 問題サーバーを配置するAWSのサブネットID }}"
-    security_group_id: "{{ 問題サーバーを配置するAWSのセキュリティグループID }}"
+    security_group_id: "{{ CDK の ProblemSecurityGroupId に出力された問題サーバー用セキュリティグループID }}"
     key_pair_name: "{{ AWSのキーペア名 }}"
 
   runner:

--- a/provisioning/aws/README.md
+++ b/provisioning/aws/README.md
@@ -64,3 +64,5 @@ cdk deploy
 ```
 
 デプロイが完了すると、Portal サーバーの IP アドレスなどがコンソールに出力されます。
+出力される `ProblemSecurityGroupId` は、Portal が起動する問題サーバー用の Security Group ID です。
+Ansible で Portal を設定するときは、この値を `local.aws.security_group_id` に指定してください。

--- a/provisioning/aws/lib/aws-stack.ts
+++ b/provisioning/aws/lib/aws-stack.ts
@@ -52,10 +52,45 @@ export class AwsStack extends cdk.Stack {
 			description: "Securty group for Runners",
 		});
 
+		const problemServerSg = new ec2.SecurityGroup(this, "ProblemServerSg", {
+			vpc,
+			description: "Security group for problem servers",
+		});
+
 		portalSg.addIngressRule(
 			runnerSg,
 			ec2.Port.tcp(50051),
 			"Allow gRPC from any Runner",
+		);
+		problemServerSg.addIngressRule(
+			runnerSg,
+			ec2.Port.allTcp(),
+			"Allow TCP from runners",
+		);
+		problemServerSg.addIngressRule(
+			runnerSg,
+			ec2.Port.allUdp(),
+			"Allow UDP from runners",
+		);
+		problemServerSg.addIngressRule(
+			problemServerSg,
+			ec2.Port.allTcp(),
+			"Allow TCP between problem servers",
+		);
+		problemServerSg.addIngressRule(
+			problemServerSg,
+			ec2.Port.allUdp(),
+			"Allow UDP between problem servers",
+		);
+		runnerSg.addIngressRule(
+			problemServerSg,
+			ec2.Port.allTcp(),
+			"Allow TCP from problem servers",
+		);
+		runnerSg.addIngressRule(
+			problemServerSg,
+			ec2.Port.allUdp(),
+			"Allow UDP from problem servers",
 		);
 
 		const portal = new ec2.Instance(this, "Portal", {
@@ -129,6 +164,10 @@ export class AwsStack extends cdk.Stack {
 		new cdk.CfnOutput(this, "PortalPublicIp", {
 			value: portal.instancePublicIp,
 			description: "Portal server public IP address",
+		});
+		new cdk.CfnOutput(this, "ProblemSecurityGroupId", {
+			value: problemServerSg.securityGroupId,
+			description: "Security group ID for problem servers",
 		});
 
 		for (let i = 0; i < props.runner.count; i++) {


### PR DESCRIPTION
以下の通信を許可するようにする

- runner -(tcp,udp)-> 問題 (ベンチマーカー実行）
- 問題 -(tcp,udp)-> runner (ISUCON 11 予選の JIA のやつ)
- 問題 -(tcp,udp)-> 問題 （アプリDB分割など） 


- **:sparkles: 問題サーバー用のセキュリティグループ作る**
- **:memo: セキュリティグループに関するドキュメント追加**
