### PR TITLE
:bug: 複数のrunnerがいる時に同じjobを選んでしまうのを修正

### DIFF
--- a/server/repository/benchmark.go
+++ b/server/repository/benchmark.go
@@ -19,6 +19,7 @@ type BenchmarkRepository interface {
 	// GetBenchmarkLog returns a benchmark log.
 	GetBenchmarkLog(ctx context.Context, benchmarkID uuid.UUID) (domain.BenchmarkLog, error)
 	// GetOldestQueuedBenchmark returns the oldest queued benchmark.
+	// To prevent the same benchmark from being claimed concurrently, it must be called in a transaction.
 	// If there are no queued benchmarks, it returns [ErrNotFound].
 	GetOldestQueuedBenchmark(ctx context.Context) (domain.Benchmark, error)
 	// UpdateBenchmark updates a benchmark record.

--- a/server/repository/db/benchmark.go
+++ b/server/repository/db/benchmark.go
@@ -104,9 +104,10 @@ func (r *Repository) GetOldestQueuedBenchmark(ctx context.Context) (domain.Bench
 	statusWaiting := models.SelectWhere.Benchmarks.Status.EQ(enums.BenchmarksStatusWaiting)
 	orderByCreatedAtAsc := sm.OrderBy(models.Benchmarks.Columns.CreatedAt).Asc()
 	limit1 := sm.Limit(1)
+	lockForUpdate := sm.ForUpdate().SkipLocked()
 	benchmark, err := models.Benchmarks.Query(
 		models.Preload.Benchmark.Instance(),
-		statusWaiting, orderByCreatedAtAsc, limit1).One(ctx, r.executor(ctx))
+		statusWaiting, orderByCreatedAtAsc, limit1, lockForUpdate).One(ctx, r.executor(ctx))
 	if errors.Is(err, sql.ErrNoRows) {
 		return domain.Benchmark{}, repository.ErrNotFound
 	}


### PR DESCRIPTION
`FOR UPDATE SKIP LOCKED` をつけて、トランザクション外から select しようとすると 1 個飛ばされるようにした。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * ベンチマーク処理が同時に実行された場合でも、同じ待機中ベンチマークが重複して取得されにくくなりました。
  * ロック中のベンチマークを自動的にスキップし、処理待ちの別ベンチマークを取得できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->