### PR TITLE
fix: スコア推移のグラフの様子がおかしいのを修正

### DIFF
--- a/client/src/components/LineChart.vue
+++ b/client/src/components/LineChart.vue
@@ -58,7 +58,6 @@ onMounted(async () => {
   Chart.register(LineController, LineElement, LinearScale, PointElement, TimeScale, Tooltip)
 
   chart = new Chart(ctx, structuredClone(props.config))
-  chart.update()
 })
 
 onUnmounted(() => {
@@ -83,10 +82,8 @@ watch(
       return
     }
 
-    console.log('Updating chart data', newData)
-
     chart.data.datasets = newData.datasets
-    chart.update()
+    chart.update('none')
   },
   { deep: true },
 )

--- a/client/src/components/ScoreChart.vue
+++ b/client/src/components/ScoreChart.vue
@@ -36,14 +36,19 @@ const colors = [
   '#fd7e1499',
 ]
 
+const getTeamColor = (teamId: string) => {
+  const hash = [...teamId].reduce((value, char) => (value * 31 + char.charCodeAt(0)) >>> 0, 0)
+  return colors[hash % colors.length]
+}
+
 const config = computed<ChartConfiguration<'line', { x: string; y: number }[], unknown>>(() => ({
   type: 'line',
   data: {
-    datasets: Object.entries(scoresByTeam.value).map(([teamId, scores], index) => ({
+    datasets: Object.entries(scoresByTeam.value).map(([teamId, scores]) => ({
       label: getTeamName(teamId),
       data: scores,
       fill: false,
-      borderColor: colors[index % colors.length],
+      borderColor: getTeamColor(teamId),
       tension: 0.1,
     })),
   },


### PR DESCRIPTION
毎秒ぐらいのペースでアニメーション付きで再描画されるのをやめて、かつ色を決定的にした

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 折れ線グラフの更新時アニメーションを抑制し、データ変更時の表示をよりスムーズにしました。
  - グラフ初期表示時の不要な更新処理を削減しました。
  - チームごとのスコアグラフの線色を一貫して表示できるよう改善しました。
  - 不要なログ出力を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->