### PR TITLE
fix(BenchView): 「ベンチマーク一覧に戻る」リンクがクリックできない不具合を修正

### DIFF
--- a/client/src/components/TeamBenchmarkDetail.vue
+++ b/client/src/components/TeamBenchmarkDetail.vue
@@ -43,6 +43,10 @@ watch(
 <template>
   <div>
     <div class="bench-detail-actions">
+      <NavigationLink to="/benches" class="back-button">
+        <Icon icon="mdi:chevron-left" width="24" height="24" />
+        <span>ベンチマーク一覧に戻る</span>
+      </NavigationLink>
       <MainButton
         @click="reEnqueueBenchmark"
         :disabled="!canReEnqueue"
@@ -80,7 +84,20 @@ watch(
 <style scoped>
 .bench-detail-actions {
   display: flex;
-  justify-content: flex-end;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+.back-button {
+  width: fit-content;
+  padding: 0.25rem 0.5rem;
+  display: flex;
+  align-items: center;
+}
+.back-button svg {
+  margin-top: 0.15rem;
 }
 </style>

--- a/client/src/views/BenchView.vue
+++ b/client/src/views/BenchView.vue
@@ -11,17 +11,13 @@ const benchId = params.id as string
 
 <template>
   <main class="bench-container">
-    <div>
+    <TeamBenchmarkDetail v-if="me?.teamId !== undefined" :teamId="me.teamId" :benchId="benchId" />
+    <div v-else>
       <NavigationLink to="/benches" class="back-button">
         <Icon icon="mdi:chevron-left" width="24" height="24" />
         <span>ベンチマーク一覧に戻る</span>
       </NavigationLink>
-    </div>
-    <div v-if="me?.teamId !== undefined" class="bench-detail-wrapper">
-      <TeamBenchmarkDetail :teamId="me.teamId" :benchId="benchId" />
-    </div>
-    <div v-if="me !== undefined && me?.teamId === undefined">
-      <p>チームに所属していません</p>
+      <p v-if="me !== undefined">チームに所属していません</p>
     </div>
   </main>
 </template>
@@ -32,17 +28,6 @@ const benchId = params.id as string
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  container-type: inline-size;
-}
-
-.bench-detail-wrapper {
-  margin-top: -3rem;
-}
-
-@container (max-width: 480px) {
-  .bench-detail-wrapper {
-    margin-top: 0rem;
-  }
 }
 
 .back-button {


### PR DESCRIPTION
ベンチマーク詳細ページ (BenchView) で、「ベンチマーク一覧に戻る」リンクが負のマージンで再実行ボタンの下に重なってクリックできなくなっていたので直しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ベンチマーク詳細画面から、左矢印付きの「ベンチマーク一覧に戻る」リンクを利用できるようになりました。
* **改善**
  * チーム所属状況に応じて、詳細画面と一覧へ戻るリンクの表示を適切に切り替えるようになりました。
  * 詳細画面のアクション領域を見直し、画面幅に応じてより整ったレイアウトで表示されるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->