### PR TITLE
fix(TeamBenchmarkDetail): ベンチマーク実行中にAPI呼び出しが際限なく増殖するバグを修正

### DIFF
--- a/client/src/components/TeamBenchmarkDetail.vue
+++ b/client/src/components/TeamBenchmarkDetail.vue
@@ -6,14 +6,17 @@ import {
   useTeamInstances,
 } from '@/lib/useServerData'
 import { Icon } from '@iconify/vue'
-import { computed, watch } from 'vue'
+import { computed } from 'vue'
 
 const { teamId, benchId } = defineProps<{
   teamId: string
   benchId: string
 }>()
 
-const { data: bench, error: benchError, refetch } = useTeamBench(teamId, benchId)
+const { data: bench, error: benchError } = useTeamBench(teamId, benchId, {
+  refetchInterval: (bench) =>
+    bench?.status === 'running' || bench?.status === 'waiting' ? 1000 : false,
+})
 const { data: benches } = useTeamBenches(teamId)
 const { mutate: enqueueBenchmark } = useEnqueueBenchmark({ redirect: true })
 const { data: instances } = useTeamInstances(teamId)
@@ -25,19 +28,6 @@ const reEnqueueBenchmark = () => {
 
   enqueueBenchmark({ teamId, instanceId: bench.value?.instanceId })
 }
-
-watch(
-  bench,
-  () => {
-    if (bench.value?.status === 'running' || bench.value?.status === 'waiting') {
-      const interval = setInterval(() => {
-        void refetch()
-      }, 1000)
-      return () => clearInterval(interval)
-    }
-  },
-  { immediate: true },
-)
 </script>
 
 <template>

--- a/client/src/lib/useServerData.ts
+++ b/client/src/lib/useServerData.ts
@@ -21,15 +21,25 @@ export const useTeamBenches = (teamId: string) =>
       api.GET('/teams/{teamId}/benchmarks', { params: { path: { teamId } } }).then((r) => r.data),
   })
 
-export const useTeamBench = (teamId: string, benchmarkId: string) =>
+const fetchTeamBench = (teamId: string, benchmarkId: string) =>
+  api
+    .GET('/teams/{teamId}/benchmarks/{benchmarkId}', {
+      params: { path: { teamId, benchmarkId } },
+    })
+    .then((r) => r.data)
+
+export const useTeamBench = (
+  teamId: string,
+  benchmarkId: string,
+  options?: {
+    // ポーリング間隔(ms)を返す。false を返すとポーリングを止める
+    refetchInterval?: (bench: Awaited<ReturnType<typeof fetchTeamBench>>) => number | false
+  },
+) =>
   useQuery({
     queryKey: ['team-bench', teamId, benchmarkId],
-    queryFn: () =>
-      api
-        .GET('/teams/{teamId}/benchmarks/{benchmarkId}', {
-          params: { path: { teamId, benchmarkId } },
-        })
-        .then((r) => r.data),
+    queryFn: () => fetchTeamBench(teamId, benchmarkId),
+    refetchInterval: (query) => options?.refetchInterval?.(query.state.data) ?? false,
   })
 
 export const useTeamInstances = (teamId: string) =>


### PR DESCRIPTION
ベンチマーク実行中のポーリングが watch のクリーンアップ漏れで際限なく増殖していたので直しました。