### PR TITLE
チームメンバーの削除ができないのを修正

### DIFF
--- a/server/domain/team.go
+++ b/server/domain/team.go
@@ -26,6 +26,22 @@ func NewTeam(name string) Team {
 	}
 }
 
+func (t *Team) SetMembers(users []User) error {
+	if len(users) >= MaxTeamMembers {
+		return errors.New("team is full")
+	}
+
+	for i, user := range users {
+		if user.TeamID.Valid && user.TeamID.UUID != t.ID {
+			return errors.New("user is already in another team")
+		}
+		users[i].TeamID = uuid.NullUUID{UUID: t.ID, Valid: true}
+	}
+
+	t.Members = users
+	return nil
+}
+
 func (t *Team) AddMember(user User) error {
 	if slices.ContainsFunc(t.Members, func(u User) bool { return u.ID == user.ID }) {
 		return nil

--- a/server/domain/team.go
+++ b/server/domain/team.go
@@ -2,7 +2,6 @@ package domain
 
 import (
 	"errors"
-	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -39,20 +38,5 @@ func (t *Team) SetMembers(users []User) error {
 	}
 
 	t.Members = users
-	return nil
-}
-
-func (t *Team) AddMember(user User) error {
-	if slices.ContainsFunc(t.Members, func(u User) bool { return u.ID == user.ID }) {
-		return nil
-	}
-	if user.TeamID.Valid && user.TeamID.UUID != t.ID {
-		return errors.New("user is already in another team")
-	}
-	if len(t.Members) >= MaxTeamMembers {
-		return errors.New("team is full")
-	}
-	user.TeamID = uuid.NullUUID{UUID: t.ID, Valid: true}
-	t.Members = append(t.Members, user)
 	return nil
 }

--- a/server/repository/db/team.go
+++ b/server/repository/db/team.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -107,7 +108,35 @@ func (r *Repository) UpdateTeam(ctx context.Context, team domain.Team) error {
 		return fmt.Errorf("update team: %w", err)
 	}
 
+	eixistingMembers, err := models.Users.Query(
+		models.SelectWhere.Users.TeamID.EQ(team.ID.String()),
+	).All(ctx, r.executor(ctx))
+	if err != nil {
+		return fmt.Errorf("get existing team members: %w", err)
+	}
+
+	existingMemberIDs := lo.Map(eixistingMembers, func(member *models.User, _ int) string { return member.ID })
 	memberIDs := lo.Map(team.Members, func(m domain.User, _ int) string { return m.ID.String() })
+
+	deletingMemberIDs := make([]string, 0, len(existingMemberIDs))
+	for _, existingID := range existingMemberIDs {
+		if !slices.Contains(memberIDs, existingID) {
+			deletingMemberIDs = append(deletingMemberIDs, existingID)
+		}
+	}
+
+	if len(deletingMemberIDs) > 0 {
+		_, err = models.Users.Update(
+			models.UpdateWhere.Users.ID.In(deletingMemberIDs...),
+			models.UserSetter{
+				TeamID: &sql.Null[string]{},
+			}.UpdateMod(),
+		).Exec(ctx, r.executor(ctx))
+		if err != nil {
+			return fmt.Errorf("update user team id to null: %w", err)
+		}
+	}
+
 	_, err = models.Users.Update(
 		models.UpdateWhere.Users.ID.In(memberIDs...),
 		models.UserSetter{

--- a/server/repository/db/team_test.go
+++ b/server/repository/db/team_test.go
@@ -151,30 +151,41 @@ func TestUpdateTeam(t *testing.T) {
 
 	repo, db := setupRepository(t)
 
+	existingMember := domain.User{
+		ID:   uuid.New(),
+		Name: "user1",
+	}
 	team := domain.Team{
 		ID:        uuid.New(),
 		Name:      "team1",
-		Members:   nil,
+		Members:   []domain.User{existingMember},
 		CreatedAt: time.Now(),
 	}
 	newMember := domain.User{
 		ID:   uuid.New(),
 		Name: "user2",
 	}
+	mustMakeUser(t, db, existingMember)
 	mustMakeUser(t, db, newMember)
 	mustMakeTeam(t, db, team)
 
 	// change the team name and add a new member
 	team.Name = "team2"
-	require.NoError(t, team.AddMember(newMember))
+	newMember.TeamID = uuid.NullUUID{UUID: team.ID, Valid: true}
+	updateQueryTeam := domain.Team{
+		ID:        team.ID,
+		Name:      team.Name,
+		Members:   []domain.User{newMember},
+		CreatedAt: team.CreatedAt,
+	}
 
-	err := repo.UpdateTeam(t.Context(), team)
+	err := repo.UpdateTeam(t.Context(), updateQueryTeam)
 	assert.NoError(t, err)
 
 	got, err := repo.FindTeam(t.Context(), team.ID)
 	require.NoError(t, err)
 
-	testutil.CompareTeam(t, team, got)
+	testutil.CompareTeam(t, updateQueryTeam, got)
 }
 
 func TestCreateTeamWithGitHubIDs(t *testing.T) {

--- a/server/usecase/team.go
+++ b/server/usecase/team.go
@@ -65,6 +65,7 @@ func (u *teamUseCaseImpl) CreateTeam(ctx context.Context, input CreateTeamInput)
 	team := domain.NewTeam(input.Name)
 	team.GitHubIDs = input.GitHubIDs
 
+	members := make([]domain.User, 0, len(input.MemberIDs))
 	for _, memberID := range input.MemberIDs {
 		user, err := u.repo.FindUser(ctx, memberID)
 		if err != nil {
@@ -73,9 +74,10 @@ func (u *teamUseCaseImpl) CreateTeam(ctx context.Context, input CreateTeamInput)
 			}
 			return domain.Team{}, fmt.Errorf("find user: %w", err)
 		}
-		if err := team.AddMember(user); err != nil {
-			return domain.Team{}, NewUseCaseError(err)
-		}
+		members = append(members, user)
+	}
+	if err := team.SetMembers(members); err != nil {
+		return domain.Team{}, NewUseCaseError(err)
 	}
 
 	if err := u.repo.CreateTeam(ctx, team); err != nil {

--- a/server/usecase/team.go
+++ b/server/usecase/team.go
@@ -107,14 +107,17 @@ func (u *teamUseCaseImpl) UpdateTeam(ctx context.Context, input UpdateTeamInput)
 		team.GitHubIDs = input.GitHubIDs
 	}
 
+	members := make([]domain.User, 0, len(input.MemberIDs))
 	for _, memberID := range input.MemberIDs {
 		user, err := u.repo.FindUser(ctx, memberID)
 		if err != nil {
 			return domain.Team{}, fmt.Errorf("find user: %w", err)
 		}
-		if err := team.AddMember(user); err != nil {
-			return domain.Team{}, fmt.Errorf("add member: %w", err)
-		}
+		members = append(members, user)
+	}
+
+	if err := team.SetMembers(members); err != nil {
+		return domain.Team{}, fmt.Errorf("set members: %w", err)
 	}
 
 	err = u.repo.UpdateTeam(ctx, team)


### PR DESCRIPTION
チームメンバーを削除するようなリクエストを送っても、削除されていなかった。

- **:bug: 指定されていないmemberは削除するようにする**
- **:white_check_mark: UpdateTeamのテストを更新**
- **:adhesive_bandage: domain.TeanでSetMembersを作る**
- **:bug: メンバーの追加ではなく修正にする**
- **:adhesive_bandage: CreateTeamでもSetMembersにする**
- **:fire: AddMemberの削除**
