### PR TITLE
ベンチマーク削除のOpenAPI

### DIFF
--- a/client/src/api/openapi.ts
+++ b/client/src/api/openapi.ts
@@ -324,7 +324,11 @@ export interface paths {
     get: operations['getBenchmarkResult']
     put?: never
     post?: never
-    delete?: never
+    /**
+     * ベンチマークの削除
+     * @description 指定されたベンチマークを削除します。adminのみが削除可能です。
+     */
+    delete: operations['deleteBenchmark']
     options?: never
     head?: never
     patch?: never
@@ -747,6 +751,8 @@ export interface components {
           name: components['schemas']['TeamName']
           /** @description チームに所属させる部員のID */
           members: components['schemas']['UserId'][]
+          /** @description メンバーのGitHub のID */
+          githubIds?: components['schemas']['GitHubId'][]
         }
       }
     }
@@ -1318,6 +1324,31 @@ export interface operations {
         content: {
           'application/json': components['schemas']['BenchmarkAdminResult']
         }
+      }
+      401: components['responses']['Unauthorized']
+      403: components['responses']['Forbidden']
+      404: components['responses']['NotFound']
+      500: components['responses']['InternalServerError']
+    }
+  }
+  deleteBenchmark: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description ベンチマークID */
+        benchmarkId: components['parameters']['benchmarkId']
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description ベンチマークの削除に成功 */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
       }
       401: components['responses']['Unauthorized']
       403: components['responses']['Forbidden']

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -563,6 +563,26 @@ paths:
           $ref: "#/components/responses/NotFound"
         500:
           $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags: ["benchmark"]
+      summary: "ベンチマークの削除"
+      description: "指定されたベンチマークを削除します。adminのみが削除可能です。"
+      operationId: "deleteBenchmark"
+      security:
+        - AdminAuth: []
+      parameters:
+        - $ref: "#/components/parameters/benchmarkId"
+      responses:
+        200:
+          description: "ベンチマークの削除に成功"
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        404:
+          $ref: "#/components/responses/NotFound"
+        500:
+          $ref: "#/components/responses/InternalServerError"
 
   /scores:
     get:

--- a/server/handler/openapi/oas_interfaces_gen.go
+++ b/server/handler/openapi/oas_interfaces_gen.go
@@ -5,6 +5,10 @@ type CreateTeamInstanceRes interface {
 	createTeamInstanceRes()
 }
 
+type DeleteBenchmarkRes interface {
+	deleteBenchmarkRes()
+}
+
 type DeleteTeamInstanceRes interface {
 	deleteTeamInstanceRes()
 }

--- a/server/handler/openapi/oas_parameters_gen.go
+++ b/server/handler/openapi/oas_parameters_gen.go
@@ -8,6 +8,12 @@ type CreateTeamInstanceParams struct {
 	TeamId TeamId
 }
 
+// DeleteBenchmarkParams is parameters of deleteBenchmark operation.
+type DeleteBenchmarkParams struct {
+	// ベンチマークID.
+	BenchmarkId BenchmarkId
+}
+
 // DeleteTeamInstanceParams is parameters of deleteTeamInstance operation.
 type DeleteTeamInstanceParams struct {
 	// チームID.

--- a/server/handler/openapi/oas_schemas_gen.go
+++ b/server/handler/openapi/oas_schemas_gen.go
@@ -609,6 +609,11 @@ func NewFinishedBenchmarkBenchmarkSum(v FinishedBenchmark) BenchmarkSum {
 
 type CreatedAt time.Time
 
+// DeleteBenchmarkOK is response for DeleteBenchmark operation.
+type DeleteBenchmarkOK struct{}
+
+func (*DeleteBenchmarkOK) deleteBenchmarkRes() {}
+
 // DeleteTeamInstanceOK is response for DeleteTeamInstance operation.
 type DeleteTeamInstanceOK struct{}
 
@@ -851,6 +856,7 @@ func (s *Forbidden) SetMessage(val OptString) {
 }
 
 func (*Forbidden) createTeamInstanceRes()     {}
+func (*Forbidden) deleteBenchmarkRes()        {}
 func (*Forbidden) deleteTeamInstanceRes()     {}
 func (*Forbidden) getBenchmarkResultRes()     {}
 func (*Forbidden) getBenchmarksRes()          {}
@@ -1193,6 +1199,7 @@ func (s *InternalServerError) SetMessage(val OptString) {
 }
 
 func (*InternalServerError) createTeamInstanceRes()     {}
+func (*InternalServerError) deleteBenchmarkRes()        {}
 func (*InternalServerError) deleteTeamInstanceRes()     {}
 func (*InternalServerError) getBenchmarkQueueRes()      {}
 func (*InternalServerError) getBenchmarkResultRes()     {}
@@ -1235,6 +1242,7 @@ func (s *NotFound) SetMessage(val OptString) {
 }
 
 func (*NotFound) createTeamInstanceRes()     {}
+func (*NotFound) deleteBenchmarkRes()        {}
 func (*NotFound) deleteTeamInstanceRes()     {}
 func (*NotFound) getBenchmarkResultRes()     {}
 func (*NotFound) getTeamBenchmarkResultRes() {}
@@ -2288,6 +2296,7 @@ func (s *Unauthorized) SetMessage(val OptString) {
 }
 
 func (*Unauthorized) createTeamInstanceRes()     {}
+func (*Unauthorized) deleteBenchmarkRes()        {}
 func (*Unauthorized) deleteTeamInstanceRes()     {}
 func (*Unauthorized) getBenchmarkQueueRes()      {}
 func (*Unauthorized) getBenchmarkResultRes()     {}


### PR DESCRIPTION
admin がベンチマークを削除できるようにしました。この前のPISCONで、途中でベンチマーカーが止まってしまうなどして、DBから直接ベンチマークを削除したりしていたので、それをAPIで用意しました。




---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>